### PR TITLE
feat: enhance leads with attachments and assignment tracking

### DIFF
--- a/02_FRONTEND_UI_CLEAN/src/pages/LeadManagement.tsx
+++ b/02_FRONTEND_UI_CLEAN/src/pages/LeadManagement.tsx
@@ -40,6 +40,8 @@ import {
   Search,
   Upload,
   Paperclip,
+  History,
+  UserPlus,
   X
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -56,9 +58,32 @@ interface Lead {
   updatedAt: string;
   files: string[];
   notes: string[];
-  source: 'website' | 'whatsapp' | 'referral' | 'social_media';
+  source: string;
   assignedTo?: string;
+  assignedToEmail?: string;
+  convertedAt?: string;
+  attachments?: LeadAttachment[];
+  statusHistory?: LeadStatusChange[];
   score?: number; // Lead score (0-100)
+}
+
+interface LeadAttachment {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  contentType?: string;
+  fileSize?: number;
+  uploadedBy?: string;
+  createdAt: string;
+}
+
+interface LeadStatusChange {
+  id: string;
+  previousStatus?: string;
+  newStatus: string;
+  changedAt: string;
+  changedBy?: string;
+  notes?: string;
 }
 
 interface KPIData {
@@ -99,6 +124,14 @@ const LeadManagement: React.FC = () => {
   const [loadingActivities, setLoadingActivities] = useState(false);
   const [newNote, setNewNote] = useState('');
   const [addingNote, setAddingNote] = useState(false);
+  const [attachments, setAttachments] = useState<LeadAttachment[]>([]);
+  const [statusHistory, setStatusHistory] = useState<LeadStatusChange[]>([]);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadingAttachment, setUploadingAttachment] = useState(false);
+  const [assignmentName, setAssignmentName] = useState('');
+  const [assignmentEmail, setAssignmentEmail] = useState('');
+  const [assignmentNotes, setAssignmentNotes] = useState('');
+  const [assigning, setAssigning] = useState(false);
   
   // Bulk operations states
   const [selectedLeads, setSelectedLeads] = useState<Set<string>>(new Set());
@@ -128,7 +161,15 @@ const LeadManagement: React.FC = () => {
             damageType: lead.damage_type || 'Other',
             location: lead.location || '',
             createdAt: lead.created_at,
-            updatedAt: lead.updated_at
+            updatedAt: lead.updated_at,
+            files: lead.files || [],
+            notes: lead.notes || [],
+            source: lead.source || 'unknown',
+            assignedTo: lead.assigned_to || '',
+            assignedToEmail: lead.assigned_to_email || '',
+            convertedAt: lead.converted_at || '',
+            attachments: [],
+            statusHistory: []
           }));
           setLeads(mappedLeads);
         }
@@ -204,11 +245,22 @@ const LeadManagement: React.FC = () => {
       });
 
       if (response.ok) {
+        const result = await response.json();
         setLeads(prev =>
           prev.map(lead =>
-            lead.id === leadId ? { ...lead, status: newStatus, updatedAt: new Date().toISOString() } : lead
+            lead.id === leadId
+              ? {
+                  ...lead,
+                  status: newStatus,
+                  updatedAt: new Date().toISOString(),
+                  convertedAt: result?.data?.converted_at || lead.convertedAt,
+                }
+              : lead
           )
         );
+        if (timelineLeadId === leadId) {
+          await loadStatusHistory(leadId);
+        }
         toast({
           title: "Status actualizat",
           description: "Statusul lead-ului a fost actualizat cu succes."
@@ -237,6 +289,8 @@ const LeadManagement: React.FC = () => {
 
     return matchesSearch && matchesStatus && matchesPriority;
   });
+
+  const currentLead = timelineLeadId ? leads.find(lead => lead.id === timelineLeadId) || null : null;
 
   const handleViewDetails = (lead: Lead) => {
     setSelectedLead(lead);
@@ -283,14 +337,23 @@ const LeadManagement: React.FC = () => {
   const openTimeline = async (leadId: string) => {
     setTimelineLeadId(leadId);
     setShowTimelineModal(true);
-    await loadTimeline(leadId);
+    const lead = leads.find(l => l.id === leadId);
+    setAssignmentName(lead?.assignedTo || '');
+    setAssignmentEmail(lead?.assignedToEmail || '');
+    setAssignmentNotes('');
+    setSelectedFile(null);
+    await Promise.all([
+      loadTimeline(leadId),
+      loadAttachments(leadId),
+      loadStatusHistory(leadId)
+    ]);
   };
 
   const loadTimeline = async (leadId: string) => {
     try {
       setLoadingActivities(true);
       const response = await fetch(`/api/leads/${leadId}/timeline`);
-      
+
       if (response.ok) {
         const data = await response.json();
         setActivities(data.activities || []);
@@ -304,6 +367,49 @@ const LeadManagement: React.FC = () => {
       });
     } finally {
       setLoadingActivities(false);
+    }
+  };
+
+  const loadAttachments = async (leadId: string) => {
+    try {
+      const response = await fetch(`/api/leads/${leadId}/attachments`);
+      if (response.ok) {
+        const data = await response.json();
+        const mapped: LeadAttachment[] = (data.items || []).map((item: any) => ({
+          id: item.id,
+          fileName: item.file_name,
+          fileUrl: item.file_url,
+          contentType: item.content_type,
+          fileSize: item.file_size,
+          uploadedBy: item.uploaded_by,
+          createdAt: item.created_at,
+        }));
+        setAttachments(mapped);
+        setLeads(prev => prev.map(lead => lead.id === leadId ? { ...lead, attachments: mapped } : lead));
+      }
+    } catch (error) {
+      console.error('Failed to load attachments:', error);
+    }
+  };
+
+  const loadStatusHistory = async (leadId: string) => {
+    try {
+      const response = await fetch(`/api/leads/${leadId}/status-history`);
+      if (response.ok) {
+        const data = await response.json();
+        const mapped: LeadStatusChange[] = (data.items || []).map((item: any) => ({
+          id: item.id,
+          previousStatus: item.previous_status,
+          newStatus: item.new_status,
+          changedAt: item.changed_at,
+          changedBy: item.changed_by,
+          notes: item.notes,
+        }));
+        setStatusHistory(mapped);
+        setLeads(prev => prev.map(lead => lead.id === leadId ? { ...lead, statusHistory: mapped } : lead));
+      }
+    } catch (error) {
+      console.error('Failed to load status history:', error);
     }
   };
 
@@ -339,6 +445,101 @@ const LeadManagement: React.FC = () => {
       });
     } finally {
       setAddingNote(false);
+    }
+  };
+
+  const handleAttachmentUpload = async () => {
+    if (!selectedFile || !timelineLeadId) {
+      toast({
+        title: "Fișier lipsă",
+        description: "Selectează un fișier înainte de a încărca.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setUploadingAttachment(true);
+      const formData = new FormData();
+      formData.append('file', selectedFile);
+      formData.append('uploaded_by', 'admin');
+      if (assignmentEmail) {
+        formData.append('notify_emails', assignmentEmail);
+      }
+
+      const response = await fetch(`/api/leads/${timelineLeadId}/attachments`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (response.ok) {
+        setSelectedFile(null);
+        await loadAttachments(timelineLeadId);
+        toast({
+          title: "Atașament încărcat",
+          description: "Fișierul a fost încărcat cu succes.",
+        });
+      } else {
+        throw new Error('Upload failed');
+      }
+    } catch (error) {
+      console.error('Failed to upload attachment:', error);
+      toast({
+        title: "Eroare la upload",
+        description: "Nu s-a putut încărca fișierul.",
+        variant: "destructive",
+      });
+    } finally {
+      setUploadingAttachment(false);
+    }
+  };
+
+  const handleAssignmentSubmit = async () => {
+    if (!timelineLeadId || !assignmentName.trim()) {
+      toast({
+        title: "Date incomplete",
+        description: "Introdu numele persoanei către care asignezi lead-ul.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setAssigning(true);
+      const response = await fetch(`/api/leads/${timelineLeadId}/assign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          assigned_to: assignmentName,
+          assigned_to_email: assignmentEmail || undefined,
+          assigned_by: 'admin',
+          notes: assignmentNotes || undefined,
+        }),
+      });
+
+      if (response.ok) {
+        setLeads(prev => prev.map(lead =>
+          lead.id === timelineLeadId
+            ? { ...lead, assignedTo: assignmentName, assignedToEmail: assignmentEmail }
+            : lead
+        ));
+        await loadTimeline(timelineLeadId);
+        toast({
+          title: "Lead asignat",
+          description: `${assignmentName} a fost notificat despre lead.`,
+        });
+      } else {
+        throw new Error('Assignment failed');
+      }
+    } catch (error) {
+      console.error('Failed to assign lead:', error);
+      toast({
+        title: "Eroare la asignare",
+        description: "Nu s-a putut asigna lead-ul.",
+        variant: "destructive",
+      });
+    } finally {
+      setAssigning(false);
     }
   };
 
@@ -954,89 +1155,272 @@ const LeadManagement: React.FC = () => {
 
       {/* Timeline Modal */}
       <Dialog open={showTimelineModal} onOpenChange={setShowTimelineModal}>
-        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+        <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Clock className="w-5 h-5 text-blue-500" />
               Activity Timeline
             </DialogTitle>
             <DialogDescription>
-              Historical activities for this lead
+              Gestionează activități, atașamente și istoricul conversiei pentru acest lead
             </DialogDescription>
           </DialogHeader>
 
-          {/* Add Note Form */}
-          <div className="border rounded-lg p-4 bg-blue-50">
-            <label className="text-sm font-medium mb-2 block">Add New Note</label>
-            <Textarea
-              value={newNote}
-              onChange={(e) => setNewNote(e.target.value)}
-              placeholder="Add a note about this lead..."
-              className="mb-2"
-              rows={3}
-            />
-            <Button 
-              onClick={handleAddNote} 
-              disabled={addingNote || !newNote.trim()}
-              size="sm"
-            >
-              {addingNote ? (
-                <>
-                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                  Adding...
-                </>
-              ) : (
-                <>
-                  <Plus className="w-4 h-4 mr-2" />
-                  Add Note
-                </>
-              )}
-            </Button>
+          <div className="grid gap-4 md:grid-cols-2 mb-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Informații Lead</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Sursă</span>
+                  <Badge variant="outline">{currentLead?.source || 'necunoscută'}</Badge>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Status curent</span>
+                  <Badge>{currentLead?.status || 'N/A'}</Badge>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Asignat către</span>
+                  <span className="font-medium">{assignmentName || 'Neasignat'}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Conversie</span>
+                  <span>
+                    {currentLead?.convertedAt
+                      ? new Date(currentLead.convertedAt).toLocaleString('ro-RO')
+                      : 'În curs'}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <UserPlus className="w-4 h-4" />
+                  Asignează lead-ul
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div>
+                  <label className="text-sm font-medium">Nume responsabil</label>
+                  <Input
+                    value={assignmentName}
+                    onChange={(e) => setAssignmentName(e.target.value)}
+                    placeholder="Ex: Manole Popescu"
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Email notificare</label>
+                  <Input
+                    type="email"
+                    value={assignmentEmail}
+                    onChange={(e) => setAssignmentEmail(e.target.value)}
+                    placeholder="responsabil@example.com"
+                  />
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Notițe</label>
+                  <Textarea
+                    value={assignmentNotes}
+                    onChange={(e) => setAssignmentNotes(e.target.value)}
+                    placeholder="Instrucțiuni sau context pentru lead"
+                    rows={3}
+                  />
+                </div>
+                <Button onClick={handleAssignmentSubmit} disabled={assigning}>
+                  {assigning ? (
+                    <>
+                      <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                      Se trimite notificarea...
+                    </>
+                  ) : (
+                    <>
+                      <UserPlus className="w-4 h-4 mr-2" />
+                      Asignează lead
+                    </>
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
           </div>
 
-          {/* Activities List */}
-          <div className="space-y-3">
-            {loadingActivities ? (
-              <div className="text-center py-8">
-                <RefreshCw className="w-6 h-6 animate-spin mx-auto mb-2 text-blue-500" />
-                <p className="text-sm text-muted-foreground">Loading timeline...</p>
+          <Card className="mb-4">
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Paperclip className="w-4 h-4" />
+                Atașamente
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col md:flex-row md:items-center gap-2">
+                <Input
+                  type="file"
+                  onChange={(event) => setSelectedFile(event.target.files?.[0] || null)}
+                  className="md:w-2/3"
+                />
+                <Button
+                  onClick={handleAttachmentUpload}
+                  disabled={uploadingAttachment || !selectedFile}
+                  variant="secondary"
+                >
+                  {uploadingAttachment ? (
+                    <>
+                      <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                      Încărcare...
+                    </>
+                  ) : (
+                    <>
+                      <Upload className="w-4 h-4 mr-2" />
+                      Încarcă fișier
+                    </>
+                  )}
+                </Button>
               </div>
-            ) : activities.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                <FileText className="w-12 h-12 mx-auto mb-2 opacity-50" />
-                <p>No activities yet</p>
-              </div>
-            ) : (
-              activities.map((activity, index) => (
-                <div key={activity.id || index} className="flex gap-3 p-3 border rounded-lg">
-                  <div className="flex-shrink-0">
-                    {activity.activity_type === 'note' && <FileText className="w-5 h-5 text-blue-500" />}
-                    {activity.activity_type === 'email' && <Mail className="w-5 h-5 text-green-500" />}
-                    {activity.activity_type === 'call' && <Phone className="w-5 h-5 text-orange-500" />}
-                    {activity.activity_type === 'status_change' && <Activity className="w-5 h-5 text-purple-500" />}
-                  </div>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="font-medium text-sm">{activity.title}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {new Date(activity.created_at).toLocaleString('ro-RO')}
-                      </span>
+
+              <div className="space-y-3 mt-4">
+                {attachments.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">Nu există atașamente pentru acest lead.</p>
+                ) : (
+                  attachments.map((attachment) => (
+                    <div
+                      key={attachment.id}
+                      className="flex items-center justify-between border rounded-lg p-3"
+                    >
+                      <div>
+                        <p className="font-medium text-sm">{attachment.fileName}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Încărcat de {attachment.uploadedBy || 'sistem'} ·{' '}
+                          {new Date(attachment.createdAt).toLocaleString('ro-RO')}
+                        </p>
+                      </div>
+                      <Button asChild variant="outline" size="sm">
+                        <a href={attachment.fileUrl} target="_blank" rel="noreferrer">
+                          <Download className="w-4 h-4 mr-1" /> Descarcă
+                        </a>
+                      </Button>
                     </div>
-                    <p className="text-sm text-muted-foreground">{activity.description}</p>
-                    {activity.performed_by && (
-                      <span className="text-xs text-muted-foreground mt-1 block">
-                        by {activity.performed_by}
-                      </span>
-                    )}
-                  </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="mb-4">
+            <CardHeader>
+              <CardTitle className="text-base flex items-center gap-2">
+                <History className="w-4 h-4" />
+                Istoric conversie
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {statusHistory.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Nu există modificări de status înregistrate.</p>
+              ) : (
+                <div className="space-y-3">
+                  {statusHistory.map((item) => (
+                    <div key={item.id} className="border rounded-lg p-3">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm">
+                          {item.previousStatus ? `${item.previousStatus} → ${item.newStatus}` : item.newStatus}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {item.changedAt ? new Date(item.changedAt).toLocaleString('ro-RO') : ''}
+                        </span>
+                      </div>
+                      {item.notes && (
+                        <p className="text-xs text-muted-foreground mt-1">{item.notes}</p>
+                      )}
+                      {item.changedBy && (
+                        <p className="text-xs text-muted-foreground mt-1">Modificat de {item.changedBy}</p>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              ))
-            )}
-          </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Activități și notițe</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="text-sm font-medium mb-2 block">Adaugă o nouă notă</label>
+                <Textarea
+                  value={newNote}
+                  onChange={(e) => setNewNote(e.target.value)}
+                  placeholder="Adaugă o notă despre lead..."
+                  className="mb-2"
+                  rows={3}
+                />
+                <Button
+                  onClick={handleAddNote}
+                  disabled={addingNote || !newNote.trim()}
+                  size="sm"
+                >
+                  {addingNote ? (
+                    <>
+                      <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                      Se salvează...
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="w-4 h-4 mr-2" />
+                      Adaugă notă
+                    </>
+                  )}
+                </Button>
+              </div>
+
+              <div className="space-y-3">
+                {loadingActivities ? (
+                  <div className="text-center py-8">
+                    <RefreshCw className="w-6 h-6 animate-spin mx-auto mb-2 text-blue-500" />
+                    <p className="text-sm text-muted-foreground">Se încarcă timeline-ul...</p>
+                  </div>
+                ) : activities.length === 0 ? (
+                  <div className="text-center py-8 text-muted-foreground">
+                    <FileText className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                    <p>Nu există activități înregistrate</p>
+                  </div>
+                ) : (
+                  activities.map((activity, index) => (
+                    <div key={activity.id || index} className="flex gap-3 p-3 border rounded-lg">
+                      <div className="flex-shrink-0">
+                        {activity.activity_type === 'note' && <FileText className="w-5 h-5 text-blue-500" />}
+                        {activity.activity_type === 'email' && <Mail className="w-5 h-5 text-green-500" />}
+                        {activity.activity_type === 'call' && <Phone className="w-5 h-5 text-orange-500" />}
+                        {activity.activity_type === 'status_change' && <Activity className="w-5 h-5 text-purple-500" />}
+                        {activity.activity_type === 'attachment' && <Paperclip className="w-5 h-5 text-slate-500" />}
+                        {activity.activity_type === 'assignment' && <UserPlus className="w-5 h-5 text-emerald-500" />}
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="font-medium text-sm">{activity.title}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {new Date(activity.created_at).toLocaleString('ro-RO')}
+                          </span>
+                        </div>
+                        <p className="text-sm text-muted-foreground">{activity.description}</p>
+                        {activity.performed_by && (
+                          <span className="text-xs text-muted-foreground mt-1 block">
+                            de {activity.performed_by}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowTimelineModal(false)}>
-              Close
+              Închide
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ autoprodaune-1/
 - 🚧 Real-time dashboard updates
 - 🚧 Advanced charts (Recharts)
 - 🚧 Email/SMS notifications
-- 🚧 File attachments
+- ✅ File attachments & lead assignment workflows
 - 🚧 Conversion funnel
 - 🚧 AI insights
 

--- a/services/api/app/models/leads.py
+++ b/services/api/app/models/leads.py
@@ -1,0 +1,68 @@
+"""Pydantic models used by the leads domain."""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class LeadAttachment(BaseModel):
+    """Metadata for a file attached to a lead."""
+
+    id: Optional[str] = Field(default=None, description="Attachment identifier")
+    lead_id: str = Field(..., description="Lead identifier")
+    file_name: str = Field(..., description="Original filename")
+    file_url: str = Field(..., description="Public URL of the uploaded file")
+    storage_key: Optional[str] = Field(default=None, description="Key/path in the storage bucket")
+    content_type: Optional[str] = Field(default=None, description="MIME type detected during upload")
+    file_size: Optional[int] = Field(default=None, description="File size in bytes")
+    uploaded_by: Optional[str] = Field(default=None, description="User that uploaded the attachment")
+    created_at: Optional[datetime] = Field(default=None, description="Timestamp when the attachment was created")
+
+
+class LeadAttachmentList(BaseModel):
+    """Response model for attachment listing."""
+
+    success: bool = True
+    lead_id: str
+    items: List[LeadAttachment]
+
+
+class LeadAssignmentRequest(BaseModel):
+    """Payload used to assign a lead to someone from the UI."""
+
+    assigned_to: str = Field(..., description="Identifier/name of the assignee")
+    assigned_to_email: Optional[EmailStr] = Field(
+        default=None, description="Email address used for notification purposes"
+    )
+    assigned_by: Optional[str] = Field(default=None, description="User performing the assignment")
+    notes: Optional[str] = Field(default=None, description="Optional context for the assignment")
+
+
+class LeadAssignmentResponse(BaseModel):
+    """Response returned after a lead assignment."""
+
+    success: bool
+    lead_id: str
+    assigned_to: str
+    assigned_by: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class LeadStatusChange(BaseModel):
+    """Represents a status transition in the conversion funnel."""
+
+    id: Optional[str] = None
+    lead_id: str
+    previous_status: Optional[str] = None
+    new_status: str
+    changed_by: Optional[str] = None
+    notes: Optional[str] = None
+    changed_at: Optional[datetime] = None
+
+
+class LeadStatusHistoryResponse(BaseModel):
+    """Response wrapper for status history queries."""
+
+    success: bool = True
+    lead_id: str
+    items: List[LeadStatusChange]

--- a/services/api/app/routes/leads.py
+++ b/services/api/app/routes/leads.py
@@ -7,14 +7,31 @@ This module provides endpoints for lead management including:
 - Lead analytics and filtering
 """
 
+import io
+import logging
+from datetime import datetime
+from uuid import uuid4
+from typing import Dict, Any, List, Optional
+
 from fastapi import APIRouter, HTTPException, Query, Depends, UploadFile, File, Form
 from pydantic import BaseModel, Field, validator
-from typing import Dict, Any, List, Optional
-from datetime import datetime
-import logging
 
 from ..core.database import get_database, DatabaseManager
-from ..core.monitoring import get_monitoring, MonitoringManager, monitor_api_call, monitor_business_operation
+from ..core.monitoring import (
+    get_monitoring,
+    MonitoringManager,
+    monitor_api_call,
+    monitor_business_operation,
+)
+from ..models.leads import (
+    LeadAttachment,
+    LeadAttachmentList,
+    LeadAssignmentRequest,
+    LeadAssignmentResponse,
+    LeadStatusChange,
+    LeadStatusHistoryResponse,
+)
+from ..services.email_service import EmailService, get_email_service
 from ..services.supabase_client import get_supabase_service_instance
 # --- PATCH: import compat pentru rulare din services\api SAU din rădăcină ---
 try:
@@ -148,22 +165,98 @@ async def get_lead(
 
 @router.put("/{lead_id}")
 async def update_lead(
-    lead_id: int,
-    update_data: Dict[str, Any]
+    lead_id: str,
+    update_data: Dict[str, Any],
+    email_service: EmailService = Depends(get_email_service)
 ) -> Dict[str, Any]:
-    """
-    Actualizează un lead existent în Supabase.
-    
-    Args:
-        lead_id: ID-ul lead-ului
-        update_data: Datele de actualizat
-        
-    Returns:
-        Dicționar cu rezultatul operației
-    """
+    """Actualizează un lead existent și salvează istoricul statusului."""
+
+    if not update_data:
+        raise HTTPException(status_code=400, detail="Nu există câmpuri de actualizat")
+
     try:
-        return get_supabase_service_instance().lead_update(lead_id, update_data)
-        
+        supabase = get_supabase_service_instance()
+
+        existing = supabase._table_select(
+            "leads",
+            "*",
+            filters=[("eq", "id", lead_id)]
+        )
+
+        if not existing:
+            raise HTTPException(status_code=404, detail=f"Lead {lead_id} nu a fost găsit")
+
+        original_lead = existing[0]
+        previous_status = original_lead.get("status")
+        new_status = update_data.get("status")
+
+        payload = update_data.copy()
+        payload["updated_at"] = datetime.utcnow().isoformat()
+
+        # Mark conversion timestamp when applicable
+        if new_status and new_status != previous_status and new_status in {"converted", "completed"}:
+            payload.setdefault("converted_at", datetime.utcnow().isoformat())
+
+        updated_rows = supabase._table_update(
+            "leads",
+            payload,
+            filters=[("eq", "id", lead_id)]
+        )
+
+        updated_lead = updated_rows[0] if updated_rows else {**original_lead, **payload}
+
+        # Track status conversion history
+        if new_status and new_status != previous_status:
+            history_payload = {
+                "lead_id": lead_id,
+                "previous_status": previous_status,
+                "new_status": new_status,
+                "changed_by": update_data.get("updated_by") or "system",
+                "notes": update_data.get("notes"),
+                "changed_at": datetime.utcnow().isoformat(),
+            }
+            supabase._table_insert("lead_status_history", history_payload)
+
+            supabase._table_insert(
+                "lead_activities",
+                {
+                    "lead_id": lead_id,
+                    "activity_type": "status_change",
+                    "title": f"Status actualizat la {new_status}",
+                    "description": update_data.get("notes") or "Status actualizat din UI",
+                    "performed_by": update_data.get("updated_by") or "system",
+                    "metadata": {
+                        "previous_status": previous_status,
+                        "new_status": new_status,
+                    },
+                    "created_at": datetime.utcnow().isoformat(),
+                },
+            )
+
+            assignment_records = supabase._table_select(
+                "lead_assignments",
+                "*",
+                filters=[("eq", "lead_id", lead_id)],
+                order=("created_at", True),
+            )
+            assignment_email = assignment_records[0].get("assigned_to_email") if assignment_records else None
+
+            await email_service.send_status_change_notification(
+                lead_name=updated_lead.get("name"),
+                lead_id=lead_id,
+                previous_status=previous_status,
+                new_status=new_status,
+                recipients=[email for email in [updated_lead.get("email"), assignment_email] if email],
+            )
+
+        return {
+            "success": True,
+            "message": "Lead actualizat cu succes",
+            "data": updated_lead,
+        }
+
+    except HTTPException:
+        raise
     except Exception as e:
         logging.error(f"Eroare la actualizarea lead-ului {lead_id}: {e}")
         raise HTTPException(status_code=500, detail=f"Eroare la actualizarea lead-ului: {str(e)}")
@@ -705,72 +798,276 @@ async def get_lead_timeline(
 
 # ==================== FILE ATTACHMENTS ====================
 
-@router.post("/upload-attachment")
+@router.post("/{lead_id}/attachments", response_model=LeadAttachment)
 async def upload_lead_attachment(
+    lead_id: str,
     file: UploadFile = File(...),
-    lead_id: str = Form(...)
-) -> Dict[str, Any]:
-    """
-    Upload file attachment for a lead.
-    
-    Args:
-        file: File to upload
-        lead_id: Lead ID
-        
-    Returns:
-        File URL and metadata
-    """
+    uploaded_by: str = Form("system"),
+    notify_emails: Optional[str] = Form(None),
+    email_service: EmailService = Depends(get_email_service)
+) -> LeadAttachment:
+    """Upload file attachment for a lead and notify relevant users."""
+
     try:
         supabase = get_supabase_service_instance()
-        
-        # Validate lead exists
-        lead = supabase._table_select("leads", "*", [("eq", "id", lead_id)])
-        if not lead or len(lead) == 0:
+
+        lead_records = supabase._table_select("leads", "*", [("eq", "id", lead_id)])
+        if not lead_records:
             raise HTTPException(status_code=404, detail="Lead not found")
-        
-        # Validate file
-        max_size = 10 * 1024 * 1024  # 10MB
+
+        lead = lead_records[0]
+
         file_content = await file.read()
+        if not file_content:
+            raise HTTPException(status_code=400, detail="Fișierul este gol")
+
+        max_size = 10 * 1024 * 1024  # 10MB
         if len(file_content) > max_size:
-            raise HTTPException(status_code=400, detail="File too large (max 10MB)")
-        
-        # Upload to Supabase Storage
-        file_key = f"leads/{lead_id}/{datetime.now().timestamp()}_{file.filename}"
+            raise HTTPException(status_code=400, detail="Fișier prea mare (max 10MB)")
+
+        storage_key = f"leads/{lead_id}/{uuid4()}_{file.filename}"
+        buffer = io.BytesIO(file_content)
+        buffer.seek(0)
         file_url = upload_file(
-            bucket_name="lead-attachments",
-            file_key=file_key,
-            file_content=file_content,
-            content_type=file.content_type
+            buffer,
+            storage_key,
+            file.content_type or "application/octet-stream",
         )
-        
-        # Update lead files array
-        current_files = lead[0].get("files", []) or []
-        if not isinstance(current_files, list):
-            current_files = []
-        
-        current_files.append(file_url)
-        
-        supabase._table_update_eq(
-            "leads",
-            "id",
-            lead_id,
-            {"files": current_files}
-        )
-        
-        logger.info(f"[LeadAttachment] Uploaded file for lead {lead_id}: {file_url}")
-        
-        return {
-            "success": True,
+
+        attachment_payload = {
+            "lead_id": lead_id,
+            "file_name": file.filename,
             "file_url": file_url,
-            "filename": file.filename,
-            "size": len(file_content)
+            "storage_key": storage_key,
+            "content_type": file.content_type,
+            "file_size": len(file_content),
+            "uploaded_by": uploaded_by,
+            "metadata": {},
+            "created_at": datetime.utcnow().isoformat(),
         }
-        
+
+        attachment_record = supabase._table_insert("lead_attachments", attachment_payload)
+
+        existing_files = lead.get("files") or []
+        if not isinstance(existing_files, list):
+            existing_files = []
+        if file_url not in existing_files:
+            existing_files.append(file_url)
+
+        supabase._table_update(
+            "leads",
+            {
+                "files": existing_files,
+                "updated_at": datetime.utcnow().isoformat(),
+            },
+            filters=[("eq", "id", lead_id)],
+        )
+
+        supabase._table_insert(
+            "lead_activities",
+            {
+                "lead_id": lead_id,
+                "activity_type": "attachment",
+                "title": f"Fișier încărcat: {file.filename}",
+                "description": f"Atașament încărcat de {uploaded_by}",
+                "performed_by": uploaded_by,
+                "metadata": {
+                    "file_url": file_url,
+                    "file_name": file.filename,
+                },
+                "created_at": datetime.utcnow().isoformat(),
+            },
+        )
+
+        recipients = []
+        if notify_emails:
+            recipients.extend([
+                email.strip()
+                for email in notify_emails.split(",")
+                if email.strip()
+            ])
+
+        assignment_records = supabase._table_select(
+            "lead_assignments",
+            "*",
+            filters=[("eq", "lead_id", lead_id)],
+            order=("created_at", True),
+        )
+        if assignment_records:
+            assignment_email = assignment_records[0].get("assigned_to_email")
+            if assignment_email:
+                recipients.append(assignment_email)
+
+        if lead.get("email"):
+            recipients.append(lead.get("email"))
+
+        recipients = list(dict.fromkeys(recipients))
+
+        await email_service.send_attachment_notification(
+            lead_name=lead.get("name"),
+            lead_id=lead_id,
+            file_name=file.filename,
+            recipients=recipients,
+        )
+
+        logger.info("[LeadAttachment] Uploaded file for lead %s", lead_id)
+
+        return LeadAttachment(**attachment_record)
+
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"[LeadAttachment] Upload error: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to upload attachment: {str(e)}")
+    except Exception as exc:
+        logger.error(f"[LeadAttachment] Upload error: {exc}")
+        raise HTTPException(status_code=500, detail=f"Failed to upload attachment: {exc}")
+
+
+@router.get("/{lead_id}/attachments", response_model=LeadAttachmentList)
+async def list_lead_attachments(lead_id: str) -> LeadAttachmentList:
+    """Return the attachment metadata for a given lead."""
+
+    try:
+        supabase = get_supabase_service_instance()
+        attachments = supabase._table_select(
+            "lead_attachments",
+            "*",
+            filters=[("eq", "lead_id", lead_id)],
+            order=("created_at", True),
+        )
+
+        items = [LeadAttachment(**attachment) for attachment in attachments or []]
+        return LeadAttachmentList(lead_id=lead_id, items=items)
+
+    except Exception as exc:
+        logger.error(f"[LeadAttachment] List error for lead {lead_id}: {exc}")
+        raise HTTPException(status_code=500, detail=f"Failed to fetch attachments: {exc}")
+
+
+@router.get("/attachments/{attachment_id}", response_model=LeadAttachment)
+async def get_attachment_metadata(attachment_id: str) -> LeadAttachment:
+    """Return metadata for a specific attachment."""
+
+    supabase = get_supabase_service_instance()
+    attachment = supabase._table_select(
+        "lead_attachments",
+        "*",
+        filters=[("eq", "id", attachment_id)],
+    )
+
+    if not attachment:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+
+    return LeadAttachment(**attachment[0])
+
+
+@router.get("/attachments/{attachment_id}/download")
+async def download_attachment(attachment_id: str) -> Dict[str, Any]:
+    """Return a direct URL to download the attachment."""
+
+    metadata = await get_attachment_metadata(attachment_id)
+    return {
+        "success": True,
+        "file_url": metadata.file_url,
+        "file_name": metadata.file_name,
+        "content_type": metadata.content_type,
+    }
+
+
+# ==================== LEAD ASSIGNMENT ====================
+
+@router.post("/{lead_id}/assign", response_model=LeadAssignmentResponse)
+async def assign_lead(
+    lead_id: str,
+    assignment: LeadAssignmentRequest,
+    email_service: EmailService = Depends(get_email_service)
+) -> LeadAssignmentResponse:
+    """Assign a lead to an operator and notify them."""
+
+    try:
+        supabase = get_supabase_service_instance()
+        lead_records = supabase._table_select("leads", "*", [("eq", "id", lead_id)])
+        if not lead_records:
+            raise HTTPException(status_code=404, detail="Lead not found")
+
+        supabase._table_update(
+            "leads",
+            {
+                "assigned_to": assignment.assigned_to,
+                "updated_at": datetime.utcnow().isoformat(),
+            },
+            filters=[("eq", "id", lead_id)],
+        )
+
+        assignment_record = supabase._table_insert(
+            "lead_assignments",
+            {
+                "lead_id": lead_id,
+                "assigned_to": assignment.assigned_to,
+                "assigned_to_email": assignment.assigned_to_email,
+                "assigned_by": assignment.assigned_by,
+                "notes": assignment.notes,
+                "created_at": datetime.utcnow().isoformat(),
+            },
+        )
+
+        supabase._table_insert(
+            "lead_activities",
+            {
+                "lead_id": lead_id,
+                "activity_type": "assignment",
+                "title": f"Lead asignat către {assignment.assigned_to}",
+                "description": assignment.notes or "Lead asignat din UI",
+                "performed_by": assignment.assigned_by or "system",
+                "metadata": assignment_record,
+                "created_at": datetime.utcnow().isoformat(),
+            },
+        )
+
+        lead = lead_records[0]
+        await email_service.send_assignment_notification(
+            lead_name=lead.get("name"),
+            lead_id=lead_id,
+            assigned_to=assignment.assigned_to,
+            assignee_email=assignment.assigned_to_email,
+            assigned_by=assignment.assigned_by,
+            notes=assignment.notes,
+        )
+
+        return LeadAssignmentResponse(
+            success=True,
+            lead_id=lead_id,
+            assigned_to=assignment.assigned_to,
+            assigned_by=assignment.assigned_by,
+            notes=assignment.notes,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"[LeadAssignment] Error assigning lead {lead_id}: {exc}")
+        raise HTTPException(status_code=500, detail=f"Failed to assign lead: {exc}")
+
+
+# ==================== STATUS HISTORY ====================
+
+@router.get("/{lead_id}/status-history", response_model=LeadStatusHistoryResponse)
+async def get_lead_status_history(lead_id: str) -> LeadStatusHistoryResponse:
+    """Return the conversion history for a lead."""
+
+    try:
+        supabase = get_supabase_service_instance()
+        history_rows = supabase._table_select(
+            "lead_status_history",
+            "*",
+            filters=[("eq", "lead_id", lead_id)],
+            order=("changed_at", True),
+        )
+
+        items = [LeadStatusChange(**row) for row in history_rows or []]
+        return LeadStatusHistoryResponse(lead_id=lead_id, items=items)
+
+    except Exception as exc:
+        logger.error(f"[LeadStatusHistory] Error retrieving history for {lead_id}: {exc}")
+        raise HTTPException(status_code=500, detail=f"Failed to fetch status history: {exc}")
 
 
 # ==================== EMAIL INTEGRATION ====================

--- a/services/api/app/services/email_service.py
+++ b/services/api/app/services/email_service.py
@@ -1,0 +1,175 @@
+"""High level helpers for sending transactional emails related to leads."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+from .email import (
+    EmailConfig,
+    EmailMessage,
+    EmailPriority,
+    EmailRecipient,
+    EmailSender,
+    EmailType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EmailService:
+    """Wrapper around :class:`EmailSender` with lead specific helpers."""
+
+    def __init__(self) -> None:
+        self._config = EmailConfig()
+        self._sender = EmailSender(self._config)
+
+    async def send_assignment_notification(
+        self,
+        *,
+        lead_name: str,
+        lead_id: str,
+        assigned_to: str,
+        assignee_email: Optional[str],
+        assigned_by: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> bool:
+        """Notify the assignee that a new lead was allocated to them."""
+
+        if not assignee_email:
+            logger.debug("Assignment notification skipped because no email was provided")
+            return False
+
+        subject = f"Ai primit un lead nou - {lead_name or 'Lead fără nume'}"
+        assigned_by_label = assigned_by or "sistem"
+        text_content = (
+            f"Salut {assigned_to},\n\n"
+            f"Lead-ul \"{lead_name or 'N/A'}\" (ID: {lead_id}) a fost asignat către tine de {assigned_by_label}.\n"
+        )
+        if notes:
+            text_content += f"\nNotițe: {notes}\n"
+        text_content += "\nSucces!\nAutoPro Daune"
+
+        html_content = (
+            f"<p>Salut <strong>{assigned_to}</strong>,</p>"
+            f"<p>Lead-ul <strong>{lead_name or 'N/A'}</strong> (ID: {lead_id}) a fost asignat către tine de {assigned_by_label}.</p>"
+        )
+        if notes:
+            html_content += f"<p><strong>Notițe:</strong> {notes}</p>"
+        html_content += "<p>Succes!<br/>AutoPro Daune</p>"
+
+        message = EmailMessage(
+            to=[EmailRecipient(email=assignee_email, name=assigned_to or assignee_email)],
+            subject=subject,
+            text_content=text_content,
+            html_content=html_content,
+            email_type=EmailType.ALERT,
+            priority=EmailPriority.HIGH,
+        )
+
+        logger.debug(
+            "Sending assignment notification for lead %s to %s", lead_id, assignee_email
+        )
+        return await self._sender.send_email(message)
+
+    async def send_status_change_notification(
+        self,
+        *,
+        lead_name: str,
+        lead_id: str,
+        previous_status: Optional[str],
+        new_status: str,
+        recipients: Iterable[str],
+    ) -> bool:
+        """Notify stakeholders that a lead changed its status."""
+
+        recipient_list = [EmailRecipient(email=email, name=email) for email in recipients if email]
+        if not recipient_list:
+            logger.debug("Skipping status change notification – no recipients provided")
+            return False
+
+        subject = f"Lead {lead_name or lead_id} a trecut la statusul '{new_status}'"
+        text_content = (
+            f"Salut,\n\nLead-ul '{lead_name or lead_id}' (ID: {lead_id}) a fost actualizat la statusul "
+            f"'{new_status}'."
+        )
+        if previous_status:
+            text_content += f" Status anterior: {previous_status}."
+        text_content += "\n\nEchipa AutoPro Daune"
+
+        html_content = (
+            f"<p>Salut,</p><p>Lead-ul <strong>{lead_name or lead_id}</strong> (ID: {lead_id}) a fost actualizat "
+            f"la statusul <strong>{new_status}</strong>.</p>"
+        )
+        if previous_status:
+            html_content += f"<p>Status anterior: <strong>{previous_status}</strong></p>"
+        html_content += "<p>Echipa AutoPro Daune</p>"
+
+        message = EmailMessage(
+            to=recipient_list,
+            subject=subject,
+            text_content=text_content,
+            html_content=html_content,
+            email_type=EmailType.ALERT,
+            priority=EmailPriority.NORMAL,
+        )
+
+        logger.debug(
+            "Sending status change notification for lead %s to %s", lead_id, [r.email for r in recipient_list]
+        )
+        return await self._sender.send_email(message)
+
+    async def send_attachment_notification(
+        self,
+        *,
+        lead_name: str,
+        lead_id: str,
+        file_name: str,
+        recipients: Iterable[str],
+    ) -> bool:
+        """Notify that a new attachment has been uploaded for a lead."""
+
+        recipient_list = [EmailRecipient(email=email, name=email) for email in recipients if email]
+        if not recipient_list:
+            logger.debug("Skipping attachment notification – no recipients provided")
+            return False
+
+        subject = f"Lead {lead_name or lead_id}: fișier nou încărcat"
+        text_content = (
+            f"Salut,\n\nA fost încărcat fișierul '{file_name}' pentru lead-ul {lead_name or lead_id} (ID: {lead_id})."
+            "\n\nEchipa AutoPro Daune"
+        )
+        html_content = (
+            f"<p>Salut,</p>"
+            f"<p>A fost încărcat fișierul <strong>{file_name}</strong> pentru lead-ul "
+            f"<strong>{lead_name or lead_id}</strong> (ID: {lead_id}).</p>"
+            "<p>Echipa AutoPro Daune</p>"
+        )
+
+        message = EmailMessage(
+            to=recipient_list,
+            subject=subject,
+            text_content=text_content,
+            html_content=html_content,
+            email_type=EmailType.ALERT,
+            priority=EmailPriority.NORMAL,
+        )
+
+        logger.debug(
+            "Sending attachment notification for lead %s to %s", lead_id, [r.email for r in recipient_list]
+        )
+        return await self._sender.send_email(message)
+
+
+def get_email_service() -> EmailService:
+    """Return a singleton instance for re-use across requests."""
+
+    global _email_service
+    try:
+        service = _email_service
+    except NameError:  # pragma: no cover - executed only once
+        service = None
+
+    if service is None:
+        service = EmailService()
+        _email_service = service
+    return service

--- a/services/api/database/quick_fix_tables.sql
+++ b/services/api/database/quick_fix_tables.sql
@@ -192,6 +192,48 @@ CREATE TRIGGER update_whatsapp_conversations_updated_at BEFORE UPDATE ON whatsap
 CREATE TRIGGER update_content_templates_updated_at BEFORE UPDATE ON content_templates
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+-- 6. lead_attachments + lead history tables
+CREATE TABLE IF NOT EXISTS lead_attachments (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    file_name TEXT NOT NULL,
+    file_url TEXT NOT NULL,
+    storage_key TEXT,
+    content_type TEXT,
+    file_size BIGINT,
+    uploaded_by TEXT,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_attachments_lead_id ON lead_attachments(lead_id);
+CREATE INDEX IF NOT EXISTS idx_lead_attachments_created_at ON lead_attachments(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS lead_status_history (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    previous_status TEXT,
+    new_status TEXT NOT NULL,
+    changed_by TEXT,
+    notes TEXT,
+    changed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_status_history_lead_id ON lead_status_history(lead_id);
+CREATE INDEX IF NOT EXISTS idx_lead_status_history_changed_at ON lead_status_history(changed_at DESC);
+
+CREATE TABLE IF NOT EXISTS lead_assignments (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    assigned_to TEXT NOT NULL,
+    assigned_to_email TEXT,
+    assigned_by TEXT,
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_assignments_lead_id ON lead_assignments(lead_id);
+
 -- Success message
 DO $$
 BEGIN

--- a/services/api/database/supabase_schema.sql
+++ b/services/api/database/supabase_schema.sql
@@ -52,6 +52,50 @@ CREATE TABLE IF NOT EXISTS lead_activities (
 CREATE INDEX IF NOT EXISTS idx_lead_activities_lead_id ON lead_activities(lead_id);
 CREATE INDEX IF NOT EXISTS idx_lead_activities_created_at ON lead_activities(created_at DESC);
 
+-- Lead attachments - physical files uploaded for a lead
+CREATE TABLE IF NOT EXISTS lead_attachments (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    file_name TEXT NOT NULL,
+    file_url TEXT NOT NULL,
+    storage_key TEXT,
+    content_type TEXT,
+    file_size BIGINT,
+    uploaded_by TEXT,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_attachments_lead_id ON lead_attachments(lead_id);
+CREATE INDEX IF NOT EXISTS idx_lead_attachments_created_at ON lead_attachments(created_at DESC);
+
+-- Lead status history - conversion funnel tracking
+CREATE TABLE IF NOT EXISTS lead_status_history (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    previous_status TEXT,
+    new_status TEXT NOT NULL,
+    changed_by TEXT,
+    notes TEXT,
+    changed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_status_history_lead_id ON lead_status_history(lead_id);
+CREATE INDEX IF NOT EXISTS idx_lead_status_history_changed_at ON lead_status_history(changed_at DESC);
+
+-- Lead assignments - track ownership changes
+CREATE TABLE IF NOT EXISTS lead_assignments (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    lead_id UUID NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    assigned_to TEXT NOT NULL,
+    assigned_to_email TEXT,
+    assigned_by TEXT,
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_assignments_lead_id ON lead_assignments(lead_id);
+
 -- Referrals table - 200 LEI referral system
 CREATE TABLE IF NOT EXISTS referrals (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -4,11 +4,14 @@ Pytest configuration and shared fixtures for AutoPro Daune API tests.
 
 import asyncio
 import os
-from typing import AsyncGenerator, Generator
+from typing import Any, AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import pytest_asyncio
+try:  # pragma: no cover - optional dependency for async fixtures
+    import pytest_asyncio
+except ImportError:  # pragma: no cover
+    pytest_asyncio = None
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
@@ -60,6 +63,12 @@ def mock_supabase():
         count=1
     )
 
+    mock_client._table_select = MagicMock(
+        return_value=[{"id": "test-id", "name": "Test Lead", "email": "lead@example.com"}]
+    )
+    mock_client._table_update = MagicMock(return_value=[{"id": "test-id"}])
+    mock_client._table_insert = MagicMock(return_value={"id": "new-id"})
+
     return mock_client
 
 
@@ -97,35 +106,83 @@ def client(test_settings, mock_supabase, mock_redis, mock_whatsapp) -> TestClien
     def override_get_whatsapp():
         return mock_whatsapp
 
+    from app.routes import leads as leads_routes
+
+    original_supabase_instance = leads_routes.get_supabase_service_instance
+    leads_routes.get_supabase_service_instance = override_get_supabase
+
+    class DummyEmailService:
+        async def send_assignment_notification(self, **_: Any) -> bool:
+            return True
+
+        async def send_status_change_notification(self, **_: Any) -> bool:
+            return True
+
+        async def send_attachment_notification(self, **_: Any) -> bool:
+            return True
+
+    original_email_service = leads_routes.get_email_service
+    leads_routes.get_email_service = lambda: DummyEmailService()
+
     app.dependency_overrides[get_supabase] = override_get_supabase
     app.dependency_overrides[get_redis] = override_get_redis
 
     with TestClient(app) as test_client:
         yield test_client
 
+    leads_routes.get_supabase_service_instance = original_supabase_instance
+    leads_routes.get_email_service = original_email_service
     app.dependency_overrides.clear()
 
 
-@pytest_asyncio.fixture
-async def async_client(test_settings, mock_supabase, mock_redis, mock_whatsapp) -> AsyncGenerator[AsyncClient, None]:
-    """Create async test client with mocked dependencies."""
+if pytest_asyncio:
 
-    def override_get_supabase():
-        return mock_supabase
+    @pytest_asyncio.fixture
+    async def async_client(test_settings, mock_supabase, mock_redis, mock_whatsapp) -> AsyncGenerator[AsyncClient, None]:
+        """Create async test client with mocked dependencies."""
 
-    def override_get_redis():
-        return mock_redis
+        def override_get_supabase():
+            return mock_supabase
 
-    def override_get_whatsapp():
-        return mock_whatsapp
+        def override_get_redis():
+            return mock_redis
 
-    app.dependency_overrides[get_supabase] = override_get_supabase
-    app.dependency_overrides[get_redis] = override_get_redis
+        def override_get_whatsapp():
+            return mock_whatsapp
 
-    async with AsyncClient(app=app, base_url="http://testserver") as ac:
-        yield ac
+        from app.routes import leads as leads_routes
 
-    app.dependency_overrides.clear()
+        original_supabase_instance = leads_routes.get_supabase_service_instance
+        leads_routes.get_supabase_service_instance = override_get_supabase
+
+        class DummyEmailService:
+            async def send_assignment_notification(self, **_: Any) -> bool:
+                return True
+
+            async def send_status_change_notification(self, **_: Any) -> bool:
+                return True
+
+            async def send_attachment_notification(self, **_: Any) -> bool:
+                return True
+
+        original_email_service = leads_routes.get_email_service
+        leads_routes.get_email_service = lambda: DummyEmailService()
+
+        app.dependency_overrides[get_supabase] = override_get_supabase
+        app.dependency_overrides[get_redis] = override_get_redis
+
+        async with AsyncClient(app=app, base_url="http://testserver") as ac:
+            yield ac
+
+        leads_routes.get_supabase_service_instance = original_supabase_instance
+        leads_routes.get_email_service = original_email_service
+        app.dependency_overrides.clear()
+
+else:  # pragma: no cover - executed only when pytest-asyncio is missing
+
+    @pytest.fixture
+    def async_client():
+        pytest.skip("pytest-asyncio is required for async client fixtures")
 
 
 @pytest.fixture

--- a/services/api/tests/test_leads.py
+++ b/services/api/tests/test_leads.py
@@ -2,9 +2,13 @@
 Tests for the leads API endpoints.
 """
 
+import io
+
 import pytest
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
+
+from app.routes import leads as leads_routes
 
 
 class TestLeadsAPI:
@@ -191,3 +195,121 @@ class TestLeadsAPI:
         response = client.get("/api/leads/stats")
         # Should handle even if not implemented
         assert response.status_code in [200, 404, 501]
+
+    def test_assign_lead_endpoint(self, client: TestClient, monkeypatch):
+        """Ensure the assignment endpoint stores data and returns success."""
+
+        class StubSupabase:
+            def __init__(self):
+                self.updated_payload = None
+
+            def _table_select(self, table: str, *args, **kwargs):
+                if table == "leads":
+                    return [{"id": "lead-1", "name": "Lead Test", "email": "lead@example.com"}]
+                if table == "lead_assignments":
+                    return []
+                return []
+
+            def _table_update(self, table: str, payload: dict, filters):
+                self.updated_payload = payload
+                return [{"id": "lead-1", **payload}]
+
+            def _table_insert(self, table: str, payload: dict):
+                return {**payload, "id": "assign-1"}
+
+        stub = StubSupabase()
+        monkeypatch.setattr(leads_routes, "get_supabase_service_instance", lambda: stub)
+
+        response = client.post(
+            "/api/leads/lead-1/assign",
+            json={
+                "assigned_to": "Agent X",
+                "assigned_to_email": "agent@example.com",
+                "assigned_by": "admin",
+                "notes": "Preia urgent"
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["assigned_to"] == "Agent X"
+        assert stub.updated_payload["assigned_to"] == "Agent X"
+
+    def test_upload_attachment_endpoint(self, client: TestClient, monkeypatch):
+        """Verify that attachments can be uploaded and metadata is returned."""
+
+        class StubSupabase:
+            def __init__(self):
+                self.attachments = []
+
+            def _table_select(self, table: str, *args, **kwargs):
+                if table == "leads":
+                    return [{"id": "lead-1", "name": "Lead Test", "email": "lead@example.com"}]
+                if table == "lead_assignments":
+                    return []
+                if table == "lead_attachments":
+                    return self.attachments
+                return []
+
+            def _table_update(self, *args, **kwargs):
+                return [{"id": "lead-1"}]
+
+            def _table_insert(self, table: str, payload: dict):
+                record = {**payload, "id": "att-1"}
+                if table == "lead_attachments":
+                    self.attachments.insert(0, record)
+                return record
+
+        stub = StubSupabase()
+        monkeypatch.setattr(leads_routes, "get_supabase_service_instance", lambda: stub)
+        monkeypatch.setattr(
+            leads_routes,
+            "upload_file",
+            lambda *args, **kwargs: "https://example.com/test.txt",
+        )
+
+        response = client.post(
+            "/api/leads/lead-1/attachments",
+            files={"file": ("test.txt", io.BytesIO(b"hello"), "text/plain")},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["file_name"] == "test.txt"
+        assert stub.attachments[0]["file_name"] == "test.txt"
+
+    def test_status_history_endpoint(self, client: TestClient, monkeypatch):
+        """Ensure status history is returned in the expected format."""
+
+        class StubSupabase:
+            def _table_select(self, table: str, *args, **kwargs):
+                if table == "lead_status_history":
+                    return [
+                        {
+                            "id": "hist-1",
+                            "lead_id": "lead-1",
+                            "previous_status": "new",
+                            "new_status": "contacted",
+                            "changed_by": "admin",
+                            "changed_at": "2024-01-01T10:00:00",
+                            "notes": "Sunat clientul",
+                        }
+                    ]
+                if table == "leads":
+                    return [{"id": "lead-1"}]
+                return []
+
+            def _table_update(self, *args, **kwargs):
+                return [{"id": "lead-1"}]
+
+        stub = StubSupabase()
+        monkeypatch.setattr(leads_routes, "get_supabase_service_instance", lambda: stub)
+
+        response = client.get("/api/leads/lead-1/status-history")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lead_id"] == "lead-1"
+        assert len(data["items"]) == 1
+        assert data["items"][0]["new_status"] == "contacted"


### PR DESCRIPTION
## Summary
- add dedicated lead attachment, assignment, and status history models plus a reusable email notification service
- extend lead routes with file upload/download endpoints, assignment handling, conversion history logging, and email alerts backed by new SQL tables
- update the React lead management page to manage attachments, assignments, and conversion details while expanding unit tests and fixtures for the new flows

## Testing
- pytest tests/test_leads.py::TestLeadsAPI::test_assign_lead_endpoint *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e95b5ef8108323bb450902d163f44f