### PR TITLE
Expand financial analytics dashboards

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
       
       - name: Build and push Docker image

--- a/02_FRONTEND_UI_CLEAN/src/pages/FinancialDashboard.tsx
+++ b/02_FRONTEND_UI_CLEAN/src/pages/FinancialDashboard.tsx
@@ -1,39 +1,116 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { DollarSign, TrendingUp, TrendingDown, Target, PieChart as PieChartIcon, BarChart3, Download, RefreshCw, Calendar } from 'lucide-react';
+import {
+  DollarSign,
+  TrendingUp,
+  TrendingDown,
+  Target,
+  PieChart as PieChartIcon,
+  BarChart3,
+  Download,
+  RefreshCw,
+  Calendar,
+  Calculator,
+  FileText,
+  LineChart as LineChartIcon,
+  Layers,
+} from 'lucide-react';
 import AutoProApiService from '@/services/autoproApi';
-import { FinancialData, Revenue, Cost } from '@/types/admin';
+import {
+  FinancialData,
+  Revenue,
+  Cost,
+  FinancialBreakdown,
+  FinancialForecast,
+  FinancialTimelinePoint,
+  CostCategory,
+} from '@/types/admin';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
-import { Bar, BarChart, Line, LineChart, Pie, PieChart, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+import {
+  Bar,
+  BarChart,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Cell,
+} from 'recharts';
 import { useToast } from '@/hooks/use-toast';
+import { RecurringRevenueManager, MRRReport } from '@/components/recurring-revenue/RecurringRevenueManager';
 
 const FinancialDashboard: React.FC = () => {
   const { toast } = useToast();
   const [financialData, setFinancialData] = useState<FinancialData | null>(null);
   const [revenueData, setRevenueData] = useState<Revenue[]>([]);
   const [costData, setCostData] = useState<Cost[]>([]);
+  const [breakdownData, setBreakdownData] = useState<FinancialBreakdown | null>(null);
+  const [forecastData, setForecastData] = useState<FinancialForecast | null>(null);
+  const [profitLossData, setProfitLossData] = useState<any>(null);
+  const [costCategories, setCostCategories] = useState<CostCategory[]>([]);
+  const [newCategory, setNewCategory] = useState({
+    name: '',
+    description: '',
+    budget_cap: '',
+    color: '#2563eb',
+  });
+  const [mrrReport, setMrrReport] = useState<MRRReport | null>(null);
+  const recurringManager = useMemo(() => new RecurringRevenueManager(), []);
+  const [taxSummary, setTaxSummary] = useState({
+    vat: 0,
+    corporate: 0,
+    profitAfterTax: 0,
+  });
+  const [invoiceExportId, setInvoiceExportId] = useState('');
+  const [invoiceExportFormat, setInvoiceExportFormat] = useState<'pdf' | 'json'>('pdf');
+  const [isSavingCategory, setIsSavingCategory] = useState(false);
+  const [isExportingInvoice, setIsExportingInvoice] = useState(false);
   const [loading, setLoading] = useState(true);
-  
+
   // Date range state
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [selectedPreset, setSelectedPreset] = useState('7d');
 
   useEffect(() => {
-    loadFinancialData();
-    loadRevenueData();
-    loadCostData();
+    loadAllData();
   }, [selectedPreset, dateFrom, dateTo]);
+
+  useEffect(() => {
+    recurringManager
+      .loadSubscriptions()
+      .then(() => setMrrReport(recurringManager.generateMRRReport(selectedPreset.toUpperCase())))
+      .catch((error) => console.error('Failed to load subscriptions:', error));
+  }, [recurringManager, selectedPreset]);
+
+  useEffect(() => {
+    if (!financialData) {
+      setTaxSummary({ vat: 0, corporate: 0, profitAfterTax: 0 });
+      return;
+    }
+
+    const revenue = financialData.total_revenue ?? financialData.revenue ?? 0;
+    const costs = financialData.total_costs ?? financialData.costs ?? 0;
+    const profit = financialData.net_profit ?? financialData.profit ?? 0;
+    const vatDue = Math.max((revenue - costs) * 0.19, 0);
+    const corporateTax = profit > 0 ? profit * 0.16 : 0;
+    setTaxSummary({
+      vat: Math.round(vatDue * 100) / 100,
+      corporate: Math.round(corporateTax * 100) / 100,
+      profitAfterTax: Math.round((profit - vatDue - corporateTax) * 100) / 100,
+    });
+  }, [financialData]);
 
   const loadFinancialData = async () => {
     try {
-      setLoading(true);
-      
-      // Build query params
       const params = new URLSearchParams();
       if (dateFrom && dateTo) {
         params.append('date_from', dateFrom);
@@ -42,7 +119,7 @@ const FinancialDashboard: React.FC = () => {
       } else {
         params.append('period', selectedPreset);
       }
-      
+
       const response = await fetch(`/api/financial/dashboard?${params.toString()}`);
       const data = await response.json();
 
@@ -75,8 +152,6 @@ const FinancialDashboard: React.FC = () => {
         description: "Nu s-au putut încărca datele financiare.",
         variant: "destructive",
       });
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -108,12 +183,179 @@ const FinancialDashboard: React.FC = () => {
     }
   };
 
+  const buildPeriodParams = () => {
+    const params: Record<string, string> = {};
+    if (dateFrom && dateTo) {
+      params.date_from = dateFrom;
+      params.date_to = dateTo;
+      params.period = 'custom';
+    } else {
+      params.period = selectedPreset;
+    }
+    return params;
+  };
+
+  const loadBreakdownData = async () => {
+    try {
+      const response = await AutoProApiService.getFinancialBreakdown(buildPeriodParams());
+      setBreakdownData(response);
+    } catch (error) {
+      console.error('Failed to load breakdown data:', error);
+    }
+  };
+
+  const loadForecastData = async () => {
+    try {
+      const response = await AutoProApiService.getFinancialForecast(buildPeriodParams());
+      setForecastData(response);
+    } catch (error) {
+      console.error('Failed to load forecast data:', error);
+    }
+  };
+
+  const loadProfitLossData = async () => {
+    try {
+      const params: Record<string, string> = {};
+      if (dateFrom && dateTo) {
+        params.start_date = dateFrom;
+        params.end_date = dateTo;
+      } else {
+        const now = new Date();
+        const start = new Date();
+        const presetDays = selectedPreset.endsWith('d') ? parseInt(selectedPreset.replace('d', ''), 10) : 30;
+        start.setDate(now.getDate() - (isNaN(presetDays) ? 30 : presetDays));
+        params.start_date = start.toISOString().split('T')[0];
+        params.end_date = now.toISOString().split('T')[0];
+      }
+      const response = await AutoProApiService.getProfitLoss(params);
+      setProfitLossData(response);
+    } catch (error) {
+      console.error('Failed to load profit/loss data:', error);
+    }
+  };
+
+  const loadCostCategoryData = async () => {
+    try {
+      const response = await AutoProApiService.listCostCategories();
+      setCostCategories(response);
+    } catch (error) {
+      console.error('Failed to load cost categories:', error);
+    }
+  };
+
+  const loadAllData = async () => {
+    setLoading(true);
+    try {
+      await Promise.all([
+        loadFinancialData(),
+        loadRevenueData(),
+        loadCostData(),
+        loadBreakdownData(),
+        loadForecastData(),
+        loadProfitLossData(),
+        loadCostCategoryData(),
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const refreshAllData = async () => {
-    await Promise.all([
-      loadFinancialData(),
-      loadRevenueData(),
-      loadCostData()
-    ]);
+    await loadAllData();
+  };
+
+  const handleCreateCategory = async () => {
+    if (!newCategory.name.trim()) {
+      toast({
+        title: 'Completează numele categoriei',
+        description: 'Numele categoriei este obligatoriu pentru salvare.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      setIsSavingCategory(true);
+      const payload: any = {
+        name: newCategory.name,
+        description: newCategory.description || undefined,
+        color: newCategory.color || undefined,
+      };
+      if (newCategory.budget_cap) {
+        payload.budget_cap = parseFloat(newCategory.budget_cap);
+      }
+
+      const response = await AutoProApiService.createCostCategory(payload);
+      setCostCategories((prev) => [response, ...prev.filter((cat) => cat.slug !== response.slug)]);
+      setNewCategory({ name: '', description: '', budget_cap: '', color: '#2563eb' });
+      toast({ title: 'Categorie salvată', description: `Categoria ${response.name} a fost creată.` });
+    } catch (error) {
+      console.error('Failed to save category:', error);
+      toast({
+        title: 'Eroare',
+        description: 'Nu s-a putut salva categoria.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSavingCategory(false);
+    }
+  };
+
+  const handleDeleteCategory = async (slug: string, isDefault?: boolean) => {
+    if (isDefault) {
+      toast({
+        title: 'Categorie implicită',
+        description: 'Categoriile implicite nu pot fi șterse.',
+      });
+      return;
+    }
+
+    try {
+      await AutoProApiService.deleteCostCategory(slug);
+      setCostCategories((prev) => prev.filter((cat) => cat.slug !== slug));
+      toast({ title: 'Categorie ștearsă', description: 'Categoria a fost eliminată.' });
+    } catch (error) {
+      console.error('Failed to delete category:', error);
+      toast({
+        title: 'Eroare',
+        description: 'Nu s-a putut șterge categoria.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleInvoiceExport = async () => {
+    if (!invoiceExportId.trim()) {
+      toast({
+        title: 'ID factură necesar',
+        description: 'Introduceți un ID de factură valid pentru export.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      setIsExportingInvoice(true);
+      const blob = await AutoProApiService.exportInvoice(invoiceExportId, invoiceExportFormat);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `invoice-${invoiceExportId}.${invoiceExportFormat}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+      toast({ title: 'Factură exportată', description: `Factura ${invoiceExportId} a fost descărcată.` });
+    } catch (error) {
+      console.error('Failed to export invoice:', error);
+      toast({
+        title: 'Eroare',
+        description: 'Nu s-a putut exporta factura.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsExportingInvoice(false);
+    }
   };
 
   const exportFinancialReport = async () => {
@@ -124,7 +366,7 @@ const FinancialDashboard: React.FC = () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          period: 'current_month',
+          period: selectedPreset,
           format: 'csv'
         }),
       });
@@ -235,6 +477,11 @@ const FinancialDashboard: React.FC = () => {
   };
 
   const costBreakdown = getCostBreakdown();
+  const timelineData: FinancialTimelinePoint[] = useMemo(() => breakdownData?.timeline ?? [], [breakdownData]);
+  const costCategoryEntries = useMemo(() => Object.entries(breakdownData?.costs?.by_category ?? {}), [breakdownData]);
+  const revenueCategoryEntries = useMemo(() => Object.entries(breakdownData?.revenue?.by_category ?? {}), [breakdownData]);
+  const forecastSeries = useMemo(() => forecastData?.series ?? [], [forecastData]);
+  const categoryPalette = ['#2563eb', '#f97316', '#16a34a', '#9333ea', '#0ea5e9', '#facc15'];
 
   if (loading) {
     return (
@@ -337,6 +584,7 @@ const FinancialDashboard: React.FC = () => {
           <TabsTrigger value="revenue">Venituri</TabsTrigger>
           <TabsTrigger value="costs">Costuri</TabsTrigger>
           <TabsTrigger value="analysis">Analize</TabsTrigger>
+          <TabsTrigger value="categories">Categorii Cost</TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview" className="space-y-6">
@@ -480,6 +728,136 @@ const FinancialDashboard: React.FC = () => {
                   <p className="text-sm text-gray-600">Multiplicator Venituri</p>
                 </div>
               </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="categories" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Adaugă categorie de cost</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <Input
+                  placeholder="Nume categorie"
+                  value={newCategory.name}
+                  onChange={(e) => setNewCategory((prev) => ({ ...prev, name: e.target.value }))}
+                />
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="Buget (RON)"
+                  value={newCategory.budget_cap}
+                  onChange={(e) => setNewCategory((prev) => ({ ...prev, budget_cap: e.target.value }))}
+                />
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="color"
+                    value={newCategory.color}
+                    onChange={(e) => setNewCategory((prev) => ({ ...prev, color: e.target.value }))}
+                    className="h-10"
+                  />
+                  <span className="text-sm text-gray-500">Culoare</span>
+                </div>
+                <Button onClick={handleCreateCategory} disabled={isSavingCategory}>
+                  {isSavingCategory ? 'Se salvează...' : 'Adaugă categorie'}
+                </Button>
+              </div>
+              <Textarea
+                placeholder="Descriere (opțional)"
+                value={newCategory.description}
+                onChange={(e) => setNewCategory((prev) => ({ ...prev, description: e.target.value }))}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Categorii existente</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {costCategories.length > 0 ? (
+                costCategories.map((category) => {
+                  const allocated = breakdownData?.costs?.by_category?.[category.name] ?? 0;
+                  const budget = category.budget_cap ? Number(category.budget_cap) : undefined;
+                  const usage = budget ? Math.min((allocated / budget) * 100, 100) : 0;
+                  return (
+                    <div key={category.slug} className="border rounded-lg p-4 flex flex-col gap-3">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="w-3 h-3 rounded-full"
+                              style={{ backgroundColor: category.color || '#2563eb' }}
+                            />
+                            <h4 className="font-semibold">{category.name}</h4>
+                          </div>
+                          {category.description && (
+                            <p className="text-sm text-gray-500 mt-1">{category.description}</p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm text-gray-500">
+                            {budget ? `${Math.round(usage)}% din ${formatCurrency(budget)}` : 'Fără buget setat'}
+                          </span>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleDeleteCategory(category.slug, category.is_default)}
+                          >
+                            Șterge
+                          </Button>
+                        </div>
+                      </div>
+                      <div className="bg-slate-100 rounded-full h-2 overflow-hidden">
+                        <div
+                          className="h-full rounded-full"
+                          style={{ width: `${budget ? usage : 100}%`, backgroundColor: category.color || '#2563eb' }}
+                        />
+                      </div>
+                      <div className="text-sm text-gray-600">
+                        Costuri înregistrate: <span className="font-medium">{formatCurrency(allocated)}</span>
+                      </div>
+                    </div>
+                  );
+                })
+              ) : (
+                <p className="text-sm text-gray-500">Nu există categorii definite încă.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Export factură</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Input
+                  placeholder="ID factură"
+                  value={invoiceExportId}
+                  onChange={(e) => setInvoiceExportId(e.target.value)}
+                />
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant={invoiceExportFormat === 'pdf' ? 'default' : 'outline'}
+                    onClick={() => setInvoiceExportFormat('pdf')}
+                  >
+                    PDF
+                  </Button>
+                  <Button
+                    variant={invoiceExportFormat === 'json' ? 'default' : 'outline'}
+                    onClick={() => setInvoiceExportFormat('json')}
+                  >
+                    JSON
+                  </Button>
+                </div>
+                <Button onClick={handleInvoiceExport} disabled={isExportingInvoice}>
+                  {isExportingInvoice ? 'Se exportă...' : 'Exportă factură'}
+                </Button>
+              </div>
+              <p className="text-xs text-gray-500">Introduceți ID-ul facturii pentru a genera un PDF rapid sau un export JSON.</p>
             </CardContent>
           </Card>
         </TabsContent>
@@ -693,6 +1071,119 @@ const FinancialDashboard: React.FC = () => {
                 </div>
               </CardContent>
             </Card>
+
+            <Card className="lg:col-span-2">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <LineChartIcon className="w-5 h-5 text-sky-600" />
+                  Revenue vs Costs vs Profit
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {timelineData.length > 0 ? (
+                  <ChartContainer
+                    config={{
+                      revenue: { label: 'Venituri', color: 'hsl(var(--chart-1))' },
+                      costs: { label: 'Costuri', color: 'hsl(var(--chart-2))' },
+                      profit: { label: 'Profit', color: 'hsl(var(--chart-3))' },
+                    }}
+                    className="h-[280px]"
+                  >
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={timelineData}>
+                        <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
+                        <XAxis
+                          dataKey="date"
+                          tickLine={false}
+                          axisLine={false}
+                          tickFormatter={(value) => new Date(value).toLocaleDateString('ro-RO', { month: 'short', day: 'numeric' })}
+                        />
+                        <YAxis hide />
+                        <ChartTooltip content={<ChartTooltipContent />} />
+                        <Line type="monotone" dataKey="revenue" stroke="var(--color-revenue)" strokeWidth={2} dot={false} />
+                        <Line type="monotone" dataKey="costs" stroke="var(--color-costs, #ef4444)" strokeWidth={2} dot={false} />
+                        <Line type="monotone" dataKey="profit" stroke="var(--chart-3)" strokeWidth={2} dot={false} />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </ChartContainer>
+                ) : (
+                  <div className="text-center py-10 text-gray-400">
+                    <LineChartIcon className="w-10 h-10 mx-auto mb-2" />
+                    <p className="text-sm">Nu există suficiente date pentru a genera graficul.</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <PieChartIcon className="w-5 h-5" />
+                  Distribuție Categorii Cost
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {costCategoryEntries.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={240}>
+                    <PieChart>
+                      <Pie
+                        data={costCategoryEntries.map(([name, value]) => ({ name, value }))}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={50}
+                        outerRadius={90}
+                        paddingAngle={4}
+                      >
+                        {costCategoryEntries.map((entry, index) => (
+                          <Cell key={entry[0]} fill={categoryPalette[index % categoryPalette.length]} />
+                        ))}
+                      </Pie>
+                      <ChartTooltip content={<ChartTooltipContent />} />
+                    </PieChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="text-center py-8 text-gray-400">
+                    <PieChartIcon className="w-10 h-10 mx-auto mb-2" />
+                    <p className="text-sm">Nu există date agregate pentru categorii.</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Layers className="w-5 h-5 text-purple-600" />
+                  Distribuție Surse Venit
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {revenueCategoryEntries.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={240}>
+                    <PieChart>
+                      <Pie
+                        data={revenueCategoryEntries.map(([name, value]) => ({ name, value }))}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={40}
+                        outerRadius={90}
+                        paddingAngle={4}
+                      >
+                        {revenueCategoryEntries.map((entry, index) => (
+                          <Cell key={entry[0]} fill={categoryPalette[(index + 2) % categoryPalette.length]} />
+                        ))}
+                      </Pie>
+                      <ChartTooltip content={<ChartTooltipContent />} />
+                    </PieChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="text-center py-8 text-gray-400">
+                    <Layers className="w-10 h-10 mx-auto mb-2" />
+                    <p className="text-sm">Nu există date agregate pentru sursele de venit.</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
           </div>
         </TabsContent>
 
@@ -776,8 +1267,8 @@ const FinancialDashboard: React.FC = () => {
           </Card>
         </TabsContent>
 
-        <TabsContent value="analysis" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <TabsContent value="analysis" className="space-y-6">
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
             <Card>
               <CardHeader>
                 <CardTitle>Analiza ROI</CardTitle>
@@ -789,32 +1280,25 @@ const FinancialDashboard: React.FC = () => {
                     <p className="text-sm text-gray-600">
                       {financialData && financialData.roi > 0 ?
                         `Investiția ta generează ${financialData.roi.toFixed(1)}% ROI, ceea ce este ` +
-                        (financialData.roi >= 50 ? 'excelent' : financialData.roi >= 20 ? 'bun' : 'decent') +
+                        (financialData.roi >= 50 ? 'excelent' : financialData.roi >= 20 ? 'bun' : 'în creștere') +
                         ' pentru o afacere de servicii juridice.' :
                         'ROI-ul va fi calculat pe măsură ce generezi venituri.'
                       }
                     </p>
                   </div>
-
-                  {financialData && (
-                    <div className="space-y-3">
+                  {breakdownData && (
+                    <div className="grid grid-cols-1 gap-3 text-sm">
                       <div className="flex justify-between">
-                        <span>Cost per Lead:</span>
-                        <span className="font-medium">
-                          {financialData.costs > 0 ? formatCurrency(financialData.costs / 30) : '0 LEI'}
-                        </span>
+                        <span>Profit net:</span>
+                        <span className="font-medium text-green-600">{formatCurrency(breakdownData.profitability.net_profit)}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span>Revenue per Client:</span>
-                        <span className="font-medium">
-                          {formatCurrency(2500)}
-                        </span>
+                        <span>Marjă profit:</span>
+                        <span className="font-medium">{breakdownData.profitability.profit_margin.toFixed(2)}%</span>
                       </div>
                       <div className="flex justify-between">
-                        <span>Break-even Point:</span>
-                        <span className="font-medium">
-                          {Math.ceil(financialData.costs / 2500)} clienți/lună
-                        </span>
+                        <span>ROI:</span>
+                        <span className="font-medium">{breakdownData.profitability.roi.toFixed(2)}%</span>
                       </div>
                     </div>
                   )}
@@ -824,48 +1308,166 @@ const FinancialDashboard: React.FC = () => {
 
             <Card>
               <CardHeader>
-                <CardTitle>Proiecții</CardTitle>
+                <CardTitle className="flex items-center gap-2">
+                  <LineChartIcon className="w-5 h-5 text-sky-600" />
+                  Forecast (30 zile)
+                </CardTitle>
               </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div>
-                    <h4 className="font-medium mb-2">Creștere Proiectată (6 luni)</h4>
-                    {financialData && (
-                      <div className="space-y-2">
-                        <div className="flex justify-between">
-                          <span className="text-sm">Venituri proiectate:</span>
-                          <span className="font-medium">
-                            {formatCurrency(financialData.revenue * 1.5)}
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-sm">Profit proiectat:</span>
-                          <span className="font-medium text-green-600">
-                            {formatCurrency(financialData.profit * 1.8)}
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-sm">ROI proiectat:</span>
-                          <span className="font-medium">
-                            {(financialData.roi * 1.3).toFixed(1)}%
-                          </span>
-                        </div>
+              <CardContent className="space-y-4">
+                {forecastData ? (
+                  <>
+                    <div className="grid grid-cols-3 gap-4 text-sm">
+                      <div>
+                        <p className="text-gray-500">Venit mediu</p>
+                        <p className="font-semibold">{formatCurrency(forecastData.averages.revenue)}</p>
                       </div>
-                    )}
-                  </div>
-
-                  <div className="bg-yellow-50 p-3 rounded">
-                    <h4 className="font-medium text-yellow-800 mb-1">Recomandări</h4>
-                    <ul className="text-sm text-yellow-700 space-y-1">
-                      <li>• Optimizează costurile de marketing digital</li>
-                      <li>• Crește rata de conversie prin automation</li>
-                      <li>• Expandează programul de referral-uri</li>
-                    </ul>
-                  </div>
-                </div>
+                      <div>
+                        <p className="text-gray-500">Cost mediu</p>
+                        <p className="font-semibold">{formatCurrency(forecastData.averages.costs)}</p>
+                      </div>
+                      <div>
+                        <p className="text-gray-500">Profit mediu</p>
+                        <p className="font-semibold text-green-600">{formatCurrency(forecastData.averages.profit)}</p>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-3 gap-4 text-xs">
+                      <div className="bg-slate-50 p-3 rounded">
+                        <p className="text-gray-500 mb-1">7 zile</p>
+                        <p className="font-semibold">{formatCurrency(forecastData.forecasts['7d'].revenue)}</p>
+                        <p className="text-green-600">Profit: {formatCurrency(forecastData.forecasts['7d'].profit)}</p>
+                      </div>
+                      <div className="bg-slate-50 p-3 rounded">
+                        <p className="text-gray-500 mb-1">30 zile</p>
+                        <p className="font-semibold">{formatCurrency(forecastData.forecasts['30d'].revenue)}</p>
+                        <p className="text-green-600">Profit: {formatCurrency(forecastData.forecasts['30d'].profit)}</p>
+                      </div>
+                      <div className="bg-slate-50 p-3 rounded">
+                        <p className="text-gray-500 mb-1">90 zile</p>
+                        <p className="font-semibold">{formatCurrency(forecastData.forecasts['90d'].revenue)}</p>
+                        <p className="text-green-600">Profit: {formatCurrency(forecastData.forecasts['90d'].profit)}</p>
+                      </div>
+                    </div>
+                    <div className="h-[180px]">
+                      <ChartContainer
+                        config={{
+                          revenue: { label: 'Venituri', color: 'hsl(var(--chart-1))' },
+                          costs: { label: 'Costuri', color: 'hsl(var(--chart-2))' },
+                        }}
+                        className="h-full"
+                      >
+                        <ResponsiveContainer width="100%" height="100%">
+                          <LineChart data={forecastSeries}>
+                            <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+                            <XAxis dataKey="date" tickLine={false} axisLine={false} />
+                            <YAxis hide />
+                            <ChartTooltip content={<ChartTooltipContent />} />
+                            <Line type="monotone" dataKey="revenue" stroke="var(--color-revenue)" strokeWidth={2} dot={false} />
+                            <Line type="monotone" dataKey="costs" stroke="var(--color-costs, #ef4444)" strokeWidth={2} dot={false} />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      </ChartContainer>
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-sm text-gray-500">Datele pentru forecast nu sunt disponibile momentan.</p>
+                )}
               </CardContent>
             </Card>
           </div>
+
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Target className="w-5 h-5" />
+                  MRR & Subscriptions
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {mrrReport ? (
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div className="bg-slate-50 p-3 rounded">
+                      <p className="text-gray-500">Total MRR</p>
+                      <p className="text-lg font-semibold text-green-600">{formatCurrency(mrrReport.metrics.total_mrr)}</p>
+                    </div>
+                    <div className="bg-slate-50 p-3 rounded">
+                      <p className="text-gray-500">Active Subscriptions</p>
+                      <p className="text-lg font-semibold">{mrrReport.metrics.active_subscriptions}</p>
+                    </div>
+                    <div className="bg-slate-50 p-3 rounded">
+                      <p className="text-gray-500">Churn Rate</p>
+                      <p className="text-lg font-semibold">{mrrReport.metrics.churn_rate}%</p>
+                    </div>
+                    <div className="bg-slate-50 p-3 rounded">
+                      <p className="text-gray-500">CLV estimat</p>
+                      <p className="text-lg font-semibold">{formatCurrency(mrrReport.metrics.customer_lifetime_value)}</p>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">Se încarcă abonamentele recurente...</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Calculator className="w-5 h-5" />
+                  Calcul fiscal estimativ
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-3 gap-4 text-sm">
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">TVA estimat</p>
+                    <p className="text-lg font-semibold">{formatCurrency(taxSummary.vat)}</p>
+                  </div>
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">Impozit profit</p>
+                    <p className="text-lg font-semibold">{formatCurrency(taxSummary.corporate)}</p>
+                  </div>
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">Profit după taxe</p>
+                    <p className="text-lg font-semibold text-green-600">{formatCurrency(taxSummary.profitAfterTax)}</p>
+                  </div>
+                </div>
+                <p className="text-xs text-gray-500 mt-3">Calcule aproximative pentru TVA 19% și impozit profit 16%.</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FileText className="w-5 h-5" />
+                Profit & Loss Insights
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {profitLossData ? (
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">Perioadă</p>
+                    <p className="font-semibold">{profitLossData.start_date} - {profitLossData.end_date}</p>
+                  </div>
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">Profit mediu zilnic</p>
+                    <p className="font-semibold text-green-600">{formatCurrency(profitLossData.avg_daily_profit)}</p>
+                  </div>
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">Zi de vârf</p>
+                    <p className="font-semibold">{formatCurrency(profitLossData.best_day_profit)}</p>
+                  </div>
+                  <div className="bg-slate-50 p-3 rounded">
+                    <p className="text-gray-500">Zi slabă</p>
+                    <p className="font-semibold text-red-600">{formatCurrency(profitLossData.worst_day_profit)}</p>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">Nu există suficiente date pentru analiza profit/pierdere.</p>
+              )}
+            </CardContent>
+          </Card>
         </TabsContent>
       </Tabs>
     </div>

--- a/02_FRONTEND_UI_CLEAN/src/services/autoproApi.ts
+++ b/02_FRONTEND_UI_CLEAN/src/services/autoproApi.ts
@@ -46,6 +46,10 @@ class AutoProApiService {
   createLead = async (lead: any) => (await api.post("/api/leads", lead)).data;
   getFinancialDashboard = async (params?: any) =>
     (await api.get("/api/financial/dashboard", { params })).data;
+  getFinancialBreakdown = async (params?: any) =>
+    (await api.get("/api/financial/breakdown", { params })).data;
+  getFinancialForecast = async (params?: any) =>
+    (await api.get("/api/financial/forecast", { params })).data;
   getInvoices = async () => (await api.get("/api/financial/invoices")).data;
   createInvoice = async (invoice: any) =>
     (await api.post("/api/financial/invoices", invoice)).data;
@@ -84,6 +88,17 @@ class AutoProApiService {
   triggerAutomation = async () => (await api.post("/api/automation/trigger")).data;
   getRevenueData = async () => (await api.get("/api/financial/revenue")).data;
   getCostData = async () => (await api.get("/api/financial/costs")).data;
+  getProfitLoss = async (params: any) =>
+    (await api.get("/api/financial/profit-loss", { params })).data;
+  listCostCategories = async () => (await api.get("/api/financial/cost-categories")).data;
+  createCostCategory = async (payload: any) =>
+    (await api.post("/api/financial/cost-categories", payload)).data;
+  updateCostCategory = async (slug: string, payload: any) =>
+    (await api.put(`/api/financial/cost-categories/${slug}`, payload)).data;
+  deleteCostCategory = async (slug: string) =>
+    (await api.delete(`/api/financial/cost-categories/${slug}`)).data;
+  exportInvoice = async (invoiceId: string, format: 'pdf' | 'json' = 'pdf') =>
+    (await api.get(`/api/financial/invoices/${invoiceId}/export`, { params: { format }, responseType: 'blob' })).data;
   getSocialPosts = async () => (await api.get("/api/social/posts")).data;
   getPostAnalytics = async () => (await api.get("/api/social/analytics")).data;
   createPost = async (post: any) => (await api.post("/api/social/posts", post)).data;

--- a/02_FRONTEND_UI_CLEAN/src/types/admin.ts
+++ b/02_FRONTEND_UI_CLEAN/src/types/admin.ts
@@ -52,6 +52,71 @@ export interface FinancialData {
   end_date?: string;
 }
 
+export interface FinancialTimelinePoint {
+  date: string;
+  revenue: number;
+  costs: number;
+  profit: number;
+  cumulative_profit?: number;
+}
+
+export interface FinancialBreakdown {
+  period: string;
+  start_date?: string;
+  end_date?: string;
+  costs: {
+    total: number;
+    by_category: Record<string, number>;
+    by_provider: Record<string, number>;
+    top: Array<{
+      id?: number | string;
+      provider?: string;
+      operation?: string;
+      category?: string;
+      amount: number;
+      timestamp?: string;
+    }>;
+  };
+  revenue: {
+    total: number;
+    by_category: Record<string, number>;
+    by_source: Record<string, number>;
+    top: Array<{
+      id?: number | string;
+      source?: string;
+      category?: string;
+      amount: number;
+      timestamp?: string;
+    }>;
+  };
+  timeline: FinancialTimelinePoint[];
+  profitability: {
+    net_profit: number;
+    roi: number;
+    profit_margin: number;
+  };
+}
+
+export interface FinancialForecast {
+  period: string;
+  start_date?: string;
+  end_date?: string;
+  averages: Record<string, number>;
+  growth_rates: Record<string, number>;
+  forecasts: Record<string, { revenue: number; costs: number; profit: number; trend: string }>;
+  confidence: number;
+  series: FinancialTimelinePoint[];
+}
+
+export interface CostCategory {
+  slug: string;
+  name: string;
+  description?: string;
+  budget_cap?: number | string;
+  color?: string;
+  is_default?: boolean;
+}
+
 export interface LeadDetails {
   id: string;
   name: string;

--- a/openapi.json
+++ b/openapi.json
@@ -1,1 +1,10483 @@
-{"openapi":"3.1.0","info":{"title":"AutoPro Daune API","description":"Complete lead generation and automation system for AutoPro Daune","version":"1.0.0"},"paths":{"/health":{"get":{"summary":"Health Check","description":"Basic health check endpoint.\n\nReturns:\n    Dictionary with health status and timestamp","operationId":"health_check_health_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Health Check Health Get"}}}}}}},"/api/test/mock-data":{"get":{"summary":"Test Mock Data","description":"Test endpoint with mock data - no database dependency","operationId":"test_mock_data_api_test_mock_data_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/working-leads/create":{"post":{"summary":"Create Working Lead","description":"Working lead creation endpoint that simulates real database operations","operationId":"create_working_lead_api_working_leads_create_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkingLeadCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/metrics":{"get":{"summary":"Metrics","description":"Endpoint that serves Prometheus metrics.","operationId":"metrics_metrics_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/leads/":{"get":{"tags":["leads"],"summary":"Get Leads","description":"Obține lista de lead-uri cu filtrare și paginare.","operationId":"get_leads_api_leads__get","parameters":[{"name":"page","in":"query","required":false,"schema":{"type":"integer","minimum":1,"description":"Numărul paginii","default":1,"title":"Page"},"description":"Numărul paginii"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","maximum":100,"minimum":1,"description":"Numărul de lead-uri per pagină","default":20,"title":"Limit"},"description":"Numărul de lead-uri per pagină"},{"name":"source","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Filtrare după sursă","title":"Source"},"description":"Filtrare după sursă"},{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Filtrare după status","title":"Status"},"description":"Filtrare după status"},{"name":"search","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Căutare în nume, email sau telefon","title":"Search"},"description":"Căutare în nume, email sau telefon"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Leads Api Leads  Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["leads"],"summary":"Create Lead","description":"Creează un nou lead în sistem.","operationId":"create_lead_api_leads__post","requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/LeadCreate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Lead Api Leads  Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/{lead_id}":{"get":{"tags":["leads"],"summary":"Get Lead","description":"Obține un lead specific din Supabase.\n\nArgs:\n    lead_id: ID-ul lead-ului\n    \nReturns:\n    Dicționar cu datele lead-ului","operationId":"get_lead_api_leads__lead_id__get","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"integer","title":"Lead Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Lead Api Leads  Lead Id  Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["leads"],"summary":"Update Lead","description":"Actualizează un lead existent în Supabase.\n\nArgs:\n    lead_id: ID-ul lead-ului\n    update_data: Datele de actualizat\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"update_lead_api_leads__lead_id__put","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"integer","title":"Lead Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Update Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Update Lead Api Leads  Lead Id  Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["leads"],"summary":"Delete Lead","description":"Șterge un lead din Supabase.\n\nArgs:\n    lead_id: ID-ul lead-ului\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"delete_lead_api_leads__lead_id__delete","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"integer","title":"Lead Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Lead Api Leads  Lead Id  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/{lead_id}/score":{"post":{"tags":["leads"],"summary":"Score Lead","description":"Calculate and update lead score.\n\nArgs:\n    lead_id: ID of the lead to score\n    \nReturns:\n    Lead scoring results with priority and recommendation","operationId":"score_lead_api_leads__lead_id__score_post","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"integer","title":"Lead Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Score Lead Api Leads  Lead Id  Score Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/batch-score":{"post":{"tags":["leads"],"summary":"Batch Score Leads","description":"Batch score multiple leads and update priorities.\n\nArgs:\n    status: Optional filter by status\n    limit: Max number of leads to score\n    \nReturns:\n    Batch scoring results","operationId":"batch_score_leads_api_leads_batch_score_post","parameters":[{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Score leads with specific status","title":"Status"},"description":"Score leads with specific status"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","maximum":1000,"minimum":1,"description":"Max leads to score","default":100,"title":"Limit"},"description":"Max leads to score"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Batch Score Leads Api Leads Batch Score Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/{lead_id}/activity":{"post":{"tags":["leads"],"summary":"Create Lead Activity","description":"Create a new activity/note for a lead.\n\nArgs:\n    lead_id: Lead UUID\n    activity: Activity data\n    \nReturns:\n    Created activity","operationId":"create_lead_activity_api_leads__lead_id__activity_post","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"string","title":"Lead Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/LeadActivityCreate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Lead Activity Api Leads  Lead Id  Activity Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/bulk-update":{"post":{"tags":["leads"],"summary":"Bulk Update Leads","description":"Bulk update multiple leads.\n\nArgs:\n    lead_ids: List of lead UUIDs\n    updates: Fields to update (status, priority, assigned_to, etc.)\n    \nReturns:\n    Update results","operationId":"bulk_update_leads_api_leads_bulk_update_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/Body_bulk_update_leads_api_leads_bulk_update_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Bulk Update Leads Api Leads Bulk Update Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/export":{"post":{"tags":["leads"],"summary":"Export Leads","description":"Export leads to CSV or JSON.\n\nArgs:\n    status: Filter by status\n    source: Filter by source\n    format: Export format (csv or json)\n    \nReturns:\n    Export data","operationId":"export_leads_api_leads_export_post","parameters":[{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Status"}},{"name":"source","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Source"}},{"name":"format","in":"query","required":false,"schema":{"type":"string","pattern":"^(csv|json)$","default":"csv","title":"Format"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Export Leads Api Leads Export Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/{lead_id}/timeline":{"get":{"tags":["leads"],"summary":"Get Lead Timeline","description":"Get activity timeline for a lead.\n\nArgs:\n    lead_id: Lead UUID\n    activity_type: Optional filter by type\n    limit: Max activities to return\n    \nReturns:\n    List of activities ordered by date (newest first)","operationId":"get_lead_timeline_api_leads__lead_id__timeline_get","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"string","title":"Lead Id"}},{"name":"activity_type","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Filter by activity type","title":"Activity Type"},"description":"Filter by activity type"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","maximum":200,"minimum":1,"description":"Max activities to return","default":50,"title":"Limit"},"description":"Max activities to return"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Lead Timeline Api Leads  Lead Id  Timeline Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/upload-attachment":{"post":{"tags":["leads"],"summary":"Upload Lead Attachment","description":"Upload file attachment for a lead.\n\nArgs:\n    file: File to upload\n    lead_id: Lead ID\n    \nReturns:\n    File URL and metadata","operationId":"upload_lead_attachment_api_leads_upload_attachment_post","requestBody":{"content":{"multipart/form-data":{"schema":{"$ref":"#/components/schemas/Body_upload_lead_attachment_api_leads_upload_attachment_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Upload Lead Attachment Api Leads Upload Attachment Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/{lead_id}/send-email":{"post":{"tags":["leads"],"summary":"Send Email To Lead","description":"Send email to a lead.\n\nArgs:\n    lead_id: Lead ID\n    subject: Email subject\n    message: Email message\n    template: Optional template name\n    \nReturns:\n    Success message","operationId":"send_email_to_lead_api_leads__lead_id__send_email_post","parameters":[{"name":"lead_id","in":"path","required":true,"schema":{"type":"string","title":"Lead Id"}}],"requestBody":{"required":true,"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_send_email_to_lead_api_leads__lead_id__send_email_post"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Send Email To Lead Api Leads  Lead Id  Send Email Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/leads/email-templates":{"get":{"tags":["leads"],"summary":"Get Email Templates","description":"Get available email templates.\n\nReturns:\n    List of email templates","operationId":"get_email_templates_api_leads_email_templates_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Email Templates Api Leads Email Templates Get"}}}},"404":{"description":"Not found"}}}},"/api/referrals/":{"get":{"tags":["referrals"],"summary":"Get Referrals","description":"Obține lista de referrals din Supabase.\n\nArgs:\n    limit: Numărul maxim de referrals\n    offset: Offset pentru paginare\n    status: Status-ul referrals (opțional)\n    \nReturns:\n    Dicționar cu lista de referrals","operationId":"get_referrals_api_referrals__get","parameters":[{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Numărul maxim de referrals de returnat","default":50,"title":"Limit"},"description":"Numărul maxim de referrals de returnat"},{"name":"offset","in":"query","required":false,"schema":{"type":"integer","description":"Offset pentru paginare","default":0,"title":"Offset"},"description":"Offset pentru paginare"},{"name":"status","in":"query","required":false,"schema":{"type":"string","description":"Status-ul referrals (pending, completed, cancelled)","title":"Status"},"description":"Status-ul referrals (pending, completed, cancelled)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Referrals Api Referrals  Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["referrals"],"summary":"Create Referral","description":"Creează un referral nou în Supabase.\n\nArgs:\n    referral_data: Datele referral-ului\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"create_referral_api_referrals__post","requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Referral Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Referral Api Referrals  Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/referrals/stats":{"get":{"tags":["referrals"],"summary":"Get Referral Stats","description":"Obține statistici despre referrals din Supabase.\n\nReturns:\n    Dicționar cu statisticile","operationId":"get_referral_stats_api_referrals_stats_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Referral Stats Api Referrals Stats Get"}}}},"404":{"description":"Not found"}}}},"/api/referrals/{referral_id}/complete":{"put":{"tags":["referrals"],"summary":"Complete Referral","description":"Marchează un referral ca fiind completat în Supabase.\n\nArgs:\n    referral_id: ID-ul referral-ului\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"complete_referral_api_referrals__referral_id__complete_put","parameters":[{"name":"referral_id","in":"path","required":true,"schema":{"type":"integer","title":"Referral Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Complete Referral Api Referrals  Referral Id  Complete Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/track-cost":{"post":{"tags":["financial"],"summary":"Track Api Cost","description":"Înregistrează un cost API nou în Supabase.\n\nArgs:\n    cost_data: Datele costului de înregistrat\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"track_api_cost_api_financial_track_cost_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Cost Data"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Track Api Cost Api Financial Track Cost Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/track-cost/{cost_id}":{"put":{"tags":["financial"],"summary":"Update Api Cost","description":"Actualizează un cost API existent în Supabase.\n\nArgs:\n    cost_id: ID-ul costului de actualizat\n    cost_data: Datele noi pentru cost\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"update_api_cost_api_financial_track_cost__cost_id__put","parameters":[{"name":"cost_id","in":"path","required":true,"schema":{"type":"integer","description":"ID-ul costului","title":"Cost Id"},"description":"ID-ul costului"}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Cost Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Update Api Cost Api Financial Track Cost  Cost Id  Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["financial"],"summary":"Delete Api Cost","description":"Șterge un cost API din Supabase.\n\nArgs:\n    cost_id: ID-ul costului de șters\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"delete_api_cost_api_financial_track_cost__cost_id__delete","parameters":[{"name":"cost_id","in":"path","required":true,"schema":{"type":"integer","description":"ID-ul costului","title":"Cost Id"},"description":"ID-ul costului"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Api Cost Api Financial Track Cost  Cost Id  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/track-revenue":{"post":{"tags":["financial"],"summary":"Track Revenue","description":"Înregistrează un venit nou în Supabase.\n\nArgs:\n    revenue_data: Datele venitului de înregistrat\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"track_revenue_api_financial_track_revenue_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Revenue Data"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Track Revenue Api Financial Track Revenue Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/track-revenue/{revenue_id}":{"put":{"tags":["financial"],"summary":"Update Revenue","description":"Actualizează un venit existent în Supabase.\n\nArgs:\n    revenue_id: ID-ul venitului de actualizat\n    revenue_data: Datele noi pentru venit\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"update_revenue_api_financial_track_revenue__revenue_id__put","parameters":[{"name":"revenue_id","in":"path","required":true,"schema":{"type":"integer","description":"ID-ul venitului","title":"Revenue Id"},"description":"ID-ul venitului"}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Revenue Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Update Revenue Api Financial Track Revenue  Revenue Id  Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["financial"],"summary":"Delete Revenue","description":"Șterge un venit din Supabase.\n\nArgs:\n    revenue_id: ID-ul venitului de șters\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"delete_revenue_api_financial_track_revenue__revenue_id__delete","parameters":[{"name":"revenue_id","in":"path","required":true,"schema":{"type":"integer","description":"ID-ul venitului","title":"Revenue Id"},"description":"ID-ul venitului"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Revenue Api Financial Track Revenue  Revenue Id  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/calculate-daily-metrics/{target_date}":{"post":{"tags":["financial"],"summary":"Calculate Daily Metrics","description":"Calculează metricile financiare pentru o dată specificată.\n\nArgs:\n    target_date: Data pentru care se calculează metricile\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu metricile calculate","operationId":"calculate_daily_metrics_api_financial_calculate_daily_metrics__target_date__post","parameters":[{"name":"target_date","in":"path","required":true,"schema":{"type":"string","format":"date","description":"Data pentru care se calculează metricile","title":"Target Date"},"description":"Data pentru care se calculează metricile"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/roi/{period}":{"get":{"tags":["financial"],"summary":"Get Roi Analysis","description":"Obține analiza ROI pentru o perioadă specificată sau interval custom.\n\nArgs:\n    period: Perioada preset pentru analiză\n    date_from: Data start custom (opțional, override period)\n    date_to: Data end custom (opțional, override period)\n    \nReturns:\n    Obiect ROIData cu rezultatul","operationId":"get_roi_analysis_api_financial_roi__period__get","parameters":[{"name":"period","in":"path","required":true,"schema":{"type":"string","description":"Perioada pentru analiza ROI (today, 7d, 30d, mtd, ytd)","title":"Period"},"description":"Perioada pentru analiza ROI (today, 7d, 30d, mtd, ytd)"},{"name":"date_from","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Data start custom (YYYY-MM-DD)","title":"Date From"},"description":"Data start custom (YYYY-MM-DD)"},{"name":"date_to","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Data end custom (YYYY-MM-DD)","title":"Date To"},"description":"Data end custom (YYYY-MM-DD)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ROIAnalysisResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/payments":{"get":{"tags":["financial"],"summary":"Get Payments","description":"Get payment tracking data.","operationId":"get_payments_api_financial_payments_get","parameters":[{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Payment status filter","title":"Status"},"description":"Payment status filter"},{"name":"date_from","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Start date (YYYY-MM-DD)","title":"Date From"},"description":"Start date (YYYY-MM-DD)"},{"name":"date_to","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"End date (YYYY-MM-DD)","title":"Date To"},"description":"End date (YYYY-MM-DD)"},{"name":"client_id","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Client ID filter","title":"Client Id"},"description":"Client ID filter"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Number of payments to return","default":50,"title":"Limit"},"description":"Number of payments to return"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Payments Api Financial Payments Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["financial"],"summary":"Create Payment","description":"Create a new payment record.","operationId":"create_payment_api_financial_payments_post","requestBody":{"required":true,"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_create_payment_api_financial_payments_post"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Payment Api Financial Payments Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/payments/overview":{"get":{"tags":["financial"],"summary":"Get Payment Overview","description":"Get payment overview statistics.","operationId":"get_payment_overview_api_financial_payments_overview_get","parameters":[{"name":"period","in":"query","required":false,"schema":{"type":"string","description":"Time period (7d, 30d, 90d, 1y)","default":"30d","title":"Period"},"description":"Time period (7d, 30d, 90d, 1y)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Payment Overview Api Financial Payments Overview Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/invoices":{"get":{"tags":["financial"],"summary":"Get Invoices","description":"Get invoice data.","operationId":"get_invoices_api_financial_invoices_get","parameters":[{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Invoice status filter","title":"Status"},"description":"Invoice status filter"},{"name":"client_id","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Client ID filter","title":"Client Id"},"description":"Client ID filter"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Number of invoices to return","default":50,"title":"Limit"},"description":"Number of invoices to return"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Invoices Api Financial Invoices Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["financial"],"summary":"Create Invoice","description":"Create a new invoice.","operationId":"create_invoice_api_financial_invoices_post","requestBody":{"required":true,"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_create_invoice_api_financial_invoices_post"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Invoice Api Financial Invoices Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/budget-plans":{"get":{"tags":["financial"],"summary":"Get Budget Plans","description":"Get budget plans.","operationId":"get_budget_plans_api_financial_budget_plans_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Budget Plans Api Financial Budget Plans Get"}}}},"404":{"description":"Not found"}}},"post":{"tags":["financial"],"summary":"Create Budget Plan","description":"Create a new budget plan.","operationId":"create_budget_plan_api_financial_budget_plans_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_create_budget_plan_api_financial_budget_plans_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Create Budget Plan Api Financial Budget Plans Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/profit-loss":{"get":{"tags":["financial"],"summary":"Get Profit Loss","description":"Obține analiza profit/pierdere pentru o perioadă specificată din Supabase.\n\nArgs:\n    start_date: Data de început\n    end_date: Data de sfârșit\n    \nReturns:\n    Dicționar cu datele profit/pierdere","operationId":"get_profit_loss_api_financial_profit_loss_get","parameters":[{"name":"start_date","in":"query","required":true,"schema":{"type":"string","format":"date","description":"Data de început","title":"Start Date"},"description":"Data de început"},{"name":"end_date","in":"query","required":true,"schema":{"type":"string","format":"date","description":"Data de sfârșit","title":"End Date"},"description":"Data de sfârșit"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/dashboard":{"get":{"tags":["financial"],"summary":"Get Financial Dashboard","description":"Obține datele pentru dashboard-ul financiar din Supabase.\n\nArgs:\n    date_from: Data start pentru filtrare (opțional)\n    date_to: Data end pentru filtrare (opțional)\n    period: Perioada preset (default: 7d)\n\nReturns:\n    Dicționar cu datele dashboard-ului","operationId":"get_financial_dashboard_api_financial_dashboard_get","parameters":[{"name":"date_from","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Data start (YYYY-MM-DD)","title":"Date From"},"description":"Data start (YYYY-MM-DD)"},{"name":"date_to","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"description":"Data end (YYYY-MM-DD)","title":"Date To"},"description":"Data end (YYYY-MM-DD)"},{"name":"period","in":"query","required":false,"schema":{"type":"string","description":"Perioada (today, 7d, 30d, mtd, ytd)","default":"7d","title":"Period"},"description":"Perioada (today, 7d, 30d, mtd, ytd)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/campaigns":{"post":{"tags":["financial"],"summary":"Create Campaign","description":"Creează o campanie nouă.\n\nArgs:\n    campaign_data: Datele campaniei\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"create_campaign_api_financial_campaigns_post","requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CampaignMetricsCreate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Campaign Api Financial Campaigns Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"get":{"tags":["financial"],"summary":"Get Campaigns","description":"Obține lista de campanii.\n\nArgs:\n    limit: Numărul maxim de campanii\n    db: Sesiunea de bază de date\n    \nReturns:\n    Lista de campanii","operationId":"get_campaigns_api_financial_campaigns_get","parameters":[{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Numărul maxim de campanii de returnat","default":10,"title":"Limit"},"description":"Numărul maxim de campanii de returnat"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CampaignMetricsResponse"},"title":"Response Get Campaigns Api Financial Campaigns Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/campaigns/{campaign_id}":{"put":{"tags":["financial"],"summary":"Update Campaign","description":"Actualizează o campanie existentă.\n\nArgs:\n    campaign_id: ID-ul campaniei\n    update_data: Datele de actualizat\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"update_campaign_api_financial_campaigns__campaign_id__put","parameters":[{"name":"campaign_id","in":"path","required":true,"schema":{"type":"integer","description":"ID-ul campaniei","title":"Campaign Id"},"description":"ID-ul campaniei"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Update Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Update Campaign Api Financial Campaigns  Campaign Id  Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/credit-balance/{provider}":{"get":{"tags":["financial"],"summary":"Get Credit Balance","description":"Obține balanța de credite pentru un provider.\n\nArgs:\n    provider: Numele providerului\n    db: Sesiunea de bază de date\n    \nReturns:\n    Obiect CreditBalance cu balanța","operationId":"get_credit_balance_api_financial_credit_balance__provider__get","parameters":[{"name":"provider","in":"path","required":true,"schema":{"type":"string","description":"Providerul pentru care se obține balanța","title":"Provider"},"description":"Providerul pentru care se obține balanța"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CreditBalanceResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["financial"],"summary":"Update Credit Balance","description":"Actualizează balanța de credite pentru un provider.\n\nArgs:\n    provider: Numele providerului\n    amount: Suma de actualizat\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"update_credit_balance_api_financial_credit_balance__provider__put","parameters":[{"name":"provider","in":"path","required":true,"schema":{"type":"string","description":"Providerul pentru care se actualizează balanța","title":"Provider"},"description":"Providerul pentru care se actualizează balanța"},{"name":"amount","in":"query","required":true,"schema":{"anyOf":[{"type":"number"},{"type":"string"}],"description":"Suma de actualizat","title":"Amount"},"description":"Suma de actualizat"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Update Credit Balance Api Financial Credit Balance  Provider  Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/budget-alerts":{"post":{"tags":["financial"],"summary":"Create Budget Alert","description":"Creează o alertă de buget nouă.\n\nArgs:\n    alert_data: Datele alertei\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"create_budget_alert_api_financial_budget_alerts_post","requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/BudgetAlertCreate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Budget Alert Api Financial Budget Alerts Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"get":{"tags":["financial"],"summary":"Get Budget Alerts","description":"Obține lista de alerte de buget.\n\nArgs:\n    limit: Numărul maxim de alerte\n    db: Sesiunea de bază de date\n    \nReturns:\n    Lista de alerte de buget","operationId":"get_budget_alerts_api_financial_budget_alerts_get","parameters":[{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Numărul maxim de alerte de returnat","default":10,"title":"Limit"},"description":"Numărul maxim de alerte de returnat"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/BudgetAlertResponse"},"title":"Response Get Budget Alerts Api Financial Budget Alerts Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/calculate-cost/pika":{"post":{"tags":["financial"],"summary":"Calculate Pika Cost","description":"Calculează costul pentru generarea video cu Pika.\n\nArgs:\n    duration_seconds: Durata în secunde\n    resolution: Rezoluția (720p, 1080p, 4K)\n    quality: Calitatea (low, medium, high)\n    \nReturns:\n    Dicționar cu costul calculat","operationId":"calculate_pika_cost_api_financial_calculate_cost_pika_post","parameters":[{"name":"duration_seconds","in":"query","required":true,"schema":{"type":"integer","description":"Durata video-ului în secunde","title":"Duration Seconds"},"description":"Durata video-ului în secunde"},{"name":"resolution","in":"query","required":false,"schema":{"type":"string","description":"Rezoluția video-ului","default":"720p","title":"Resolution"},"description":"Rezoluția video-ului"},{"name":"quality","in":"query","required":false,"schema":{"type":"string","description":"Calitatea video-ului","default":"high","title":"Quality"},"description":"Calitatea video-ului"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Calculate Pika Cost Api Financial Calculate Cost Pika Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/calculate-cost/heygen":{"post":{"tags":["financial"],"summary":"Calculate Heygen Cost","description":"Calculează costul pentru generarea video cu HeyGen.\n\nArgs:\n    duration_seconds: Durata în secunde\n    avatar_type: Tipul avatarului\n    voice_type: Tipul vocii\n    \nReturns:\n    Dicționar cu costul calculat","operationId":"calculate_heygen_cost_api_financial_calculate_cost_heygen_post","parameters":[{"name":"duration_seconds","in":"query","required":true,"schema":{"type":"integer","description":"Durata video-ului în secunde","title":"Duration Seconds"},"description":"Durata video-ului în secunde"},{"name":"avatar_type","in":"query","required":false,"schema":{"type":"string","description":"Tipul avatarului","default":"default","title":"Avatar Type"},"description":"Tipul avatarului"},{"name":"voice_type","in":"query","required":false,"schema":{"type":"string","description":"Tipul vocii","default":"standard","title":"Voice Type"},"description":"Tipul vocii"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Calculate Heygen Cost Api Financial Calculate Cost Heygen Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/calculate-cost/social-media":{"post":{"tags":["financial"],"summary":"Calculate Social Media Cost","description":"Calculează costul pentru postarea pe social media.\n\nArgs:\n    platform: Platforma de postare\n    content_type: Tipul conținutului\n    file_size_mb: Mărimea fișierului\n    \nReturns:\n    Dicționar cu costul calculat","operationId":"calculate_social_media_cost_api_financial_calculate_cost_social_media_post","parameters":[{"name":"platform","in":"query","required":true,"schema":{"type":"string","description":"Platforma (TikTok, Instagram, YouTube)","title":"Platform"},"description":"Platforma (TikTok, Instagram, YouTube)"},{"name":"content_type","in":"query","required":false,"schema":{"type":"string","description":"Tipul conținutului","default":"video","title":"Content Type"},"description":"Tipul conținutului"},{"name":"file_size_mb","in":"query","required":false,"schema":{"anyOf":[{"type":"number"},{"type":"null"}],"description":"Mărimea fișierului în MB","title":"File Size Mb"},"description":"Mărimea fișierului în MB"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Calculate Social Media Cost Api Financial Calculate Cost Social Media Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/estimate-monthly-costs":{"post":{"tags":["financial"],"summary":"Estimate Monthly Costs","description":"Estimează costurile lunare bazate pe un plan de utilizare.\n\nArgs:\n    usage_plan: Planul de utilizare\n    \nReturns:\n    Dicționar cu estimarea costurilor","operationId":"estimate_monthly_costs_api_financial_estimate_monthly_costs_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Usage Plan"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Estimate Monthly Costs Api Financial Estimate Monthly Costs Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/estimate-budget-requirements":{"post":{"tags":["financial"],"summary":"Estimate Budget Requirements","description":"Estimează cerințele de buget bazate pe ROI țintă.\n\nArgs:\n    target_roi: ROI-ul țintă\n    expected_revenue: Veniturile așteptate\n    time_period_days: Perioada în zile\n    \nReturns:\n    Dicționar cu estimarea cerințelor","operationId":"estimate_budget_requirements_api_financial_estimate_budget_requirements_post","parameters":[{"name":"target_roi","in":"query","required":true,"schema":{"anyOf":[{"type":"number"},{"type":"string"}],"description":"ROI-ul țintă în procente","title":"Target Roi"},"description":"ROI-ul țintă în procente"},{"name":"expected_revenue","in":"query","required":true,"schema":{"anyOf":[{"type":"number"},{"type":"string"}],"description":"Veniturile așteptate","title":"Expected Revenue"},"description":"Veniturile așteptate"},{"name":"time_period_days","in":"query","required":false,"schema":{"type":"integer","description":"Perioada în zile","default":30,"title":"Time Period Days"},"description":"Perioada în zile"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Estimate Budget Requirements Api Financial Estimate Budget Requirements Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/optimize-costs":{"post":{"tags":["financial"],"summary":"Optimize Costs","description":"Sugerează optimizări pentru reducerea costurilor.\n\nArgs:\n    current_usage: Utilizarea curentă\n    budget_limit: Limita de buget\n    \nReturns:\n    Dicționar cu sugestiile de optimizare","operationId":"optimize_costs_api_financial_optimize_costs_post","parameters":[{"name":"budget_limit","in":"query","required":true,"schema":{"anyOf":[{"type":"number"},{"type":"string"}],"description":"Limita de buget","title":"Budget Limit"},"description":"Limita de buget"}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Current Usage"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Optimize Costs Api Financial Optimize Costs Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/financial/optimize-budget-allocation":{"post":{"tags":["financial"],"summary":"Optimize Budget Allocation","description":"Optimizează alocarea bugetului bazată pe performanța campaniilor.\n\nArgs:\n    total_budget: Bugetul total\n    campaign_performance: Performanța campaniilor\n    \nReturns:\n    Dicționar cu alocarea optimizată","operationId":"optimize_budget_allocation_api_financial_optimize_budget_allocation_post","parameters":[{"name":"total_budget","in":"query","required":true,"schema":{"anyOf":[{"type":"number"},{"type":"string"}],"description":"Bugetul total","title":"Total Budget"},"description":"Bugetul total"}],"requestBody":{"content":{"application/json":{"schema":{"type":"array","items":{"type":"object","additionalProperties":true},"description":"Performanța campaniilor","default":[],"title":"Campaign Performance"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Optimize Budget Allocation Api Financial Optimize Budget Allocation Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/summary":{"get":{"tags":["social"],"summary":"Get Social Summary","description":"Obține sumarul activității pe social media din Supabase.\n\nReturns:\n    Dicționar cu sumarul social media","operationId":"get_social_summary_api_social_summary_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Social Summary Api Social Summary Get"}}}},"404":{"description":"Not found"}}}},"/api/social/post-now":{"post":{"tags":["social"],"summary":"Post Now","description":"Postează imediat pe o platformă social media.\n\nArgs:\n    platform: Platforma pentru postare\n    background_tasks: Background tasks pentru procesare asincronă\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"post_now_api_social_post_now_post","parameters":[{"name":"platform","in":"query","required":true,"schema":{"type":"string","description":"Platforma pentru postare (tiktok, instagram, youtube)","title":"Platform"},"description":"Platforma pentru postare (tiktok, instagram, youtube)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Post Now Api Social Post Now Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/posts":{"get":{"tags":["social"],"summary":"Get Recent Posts","description":"Obține postările recente de pe social media din Supabase.\n\nArgs:\n    platform: Platforma specifică (opțional)\n    limit: Numărul maxim de postări\n    \nReturns:\n    Dicționar cu postările recente","operationId":"get_recent_posts_api_social_posts_get","parameters":[{"name":"platform","in":"query","required":false,"schema":{"type":"string","description":"Platforma specifică (opțional)","title":"Platform"},"description":"Platforma specifică (opțional)"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Numărul maxim de postări","default":20,"title":"Limit"},"description":"Numărul maxim de postări"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Recent Posts Api Social Posts Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["social"],"summary":"Create Social Post","description":"Creează o postare social media nouă în Supabase.\n\nArgs:\n    post_data: Datele postării\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"create_social_post_api_social_posts_post","requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Post Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Social Post Api Social Posts Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/posts/{post_id}":{"put":{"tags":["social"],"summary":"Update Social Post","description":"Actualizează o postare social media existentă în Supabase.\n\nArgs:\n    post_id: ID-ul postării\n    post_data: Datele noi pentru postare\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"update_social_post_api_social_posts__post_id__put","parameters":[{"name":"post_id","in":"path","required":true,"schema":{"type":"integer","title":"Post Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Post Data"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Update Social Post Api Social Posts  Post Id  Put"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["social"],"summary":"Delete Social Post","description":"Șterge o postare social media din Supabase.\n\nArgs:\n    post_id: ID-ul postării\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"delete_social_post_api_social_posts__post_id__delete","parameters":[{"name":"post_id","in":"path","required":true,"schema":{"type":"integer","title":"Post Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Social Post Api Social Posts  Post Id  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/analytics":{"get":{"tags":["social"],"summary":"Get Social Analytics","description":"Obține analitica pentru social media.\n\nArgs:\n    platform: Platforma specifică (opțional)\n    days: Numărul de zile pentru analiză\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu analitica","operationId":"get_social_analytics_api_social_analytics_get","parameters":[{"name":"platform","in":"query","required":false,"schema":{"type":"string","description":"Platforma specifică (opțional)","title":"Platform"},"description":"Platforma specifică (opțional)"},{"name":"days","in":"query","required":false,"schema":{"type":"integer","description":"Numărul de zile pentru analiză","default":7,"title":"Days"},"description":"Numărul de zile pentru analiză"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Social Analytics Api Social Analytics Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/bots/start":{"post":{"tags":["social"],"summary":"Start Social Bots","description":"Pornește bot-urile pentru social media.\n\nArgs:\n    platforms: Lista de platforme (opțional, toate dacă nu este specificat)\n    background_tasks: Background tasks\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"start_social_bots_api_social_bots_start_post","requestBody":{"content":{"application/json":{"schema":{"items":{"type":"string"},"type":"array","title":"Platforms"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Start Social Bots Api Social Bots Start Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/bots/stop":{"post":{"tags":["social"],"summary":"Stop Social Bots","description":"Oprește bot-urile pentru social media.\n\nArgs:\n    platforms: Lista de platforme (opțional, toate dacă nu este specificat)\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"stop_social_bots_api_social_bots_stop_post","requestBody":{"content":{"application/json":{"schema":{"items":{"type":"string"},"type":"array","title":"Platforms"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Stop Social Bots Api Social Bots Stop Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/followers":{"get":{"tags":["social"],"summary":"Get All Followers","description":"Get follower/subscriber counts from all social media platforms.\n\nReturns:\n    Dictionary with metrics from TikTok, Instagram, and YouTube","operationId":"get_all_followers_api_social_followers_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get All Followers Api Social Followers Get"}}}},"404":{"description":"Not found"}}}},"/api/social/followers/{platform}":{"get":{"tags":["social"],"summary":"Get Platform Followers","description":"Get follower count for a specific platform.\n\nArgs:\n    platform: Platform name (tiktok, instagram, youtube)\n    \nReturns:\n    Dictionary with platform-specific metrics","operationId":"get_platform_followers_api_social_followers__platform__get","parameters":[{"name":"platform","in":"path","required":true,"schema":{"type":"string","title":"Platform"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Platform Followers Api Social Followers  Platform  Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/social/upload-video":{"post":{"tags":["social"],"summary":"Upload Video For Posting","description":"Upload video and create social media post.\n\nSteps:\n1. Validate video file\n2. Upload to Supabase Storage\n3. Create post record in database\n4. Return success with media URL","operationId":"upload_video_for_posting_api_social_upload_video_post","requestBody":{"content":{"multipart/form-data":{"schema":{"$ref":"#/components/schemas/Body_upload_video_for_posting_api_social_upload_video_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Upload Video For Posting Api Social Upload Video Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/logs/":{"get":{"tags":["logs"],"summary":"Get Logs","description":"Obține log-urile aplicației din Supabase.\n\nArgs:\n    level: Nivelul de log\n    limit: Numărul maxim de log-uri\n    service: Serviciul specific (opțional)\n    \nReturns:\n    Dicționar cu log-urile","operationId":"get_logs_api_logs__get","parameters":[{"name":"level","in":"query","required":false,"schema":{"type":"string","description":"Nivelul de log (debug, info, warning, error, critical)","default":"info","title":"Level"},"description":"Nivelul de log (debug, info, warning, error, critical)"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Numărul maxim de log-uri","default":50,"title":"Limit"},"description":"Numărul maxim de log-uri"},{"name":"service","in":"query","required":false,"schema":{"type":"string","description":"Serviciul specific (opțional)","title":"Service"},"description":"Serviciul specific (opțional)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Logs Api Logs  Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["logs"],"summary":"Clear Logs","description":"Șterge log-urile vechi.\n\nArgs:\n    older_than_days: Șterge log-urile mai vechi de X zile\n    level: Nivelul specific (opțional)\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"clear_logs_api_logs__delete","parameters":[{"name":"older_than_days","in":"query","required":false,"schema":{"type":"integer","description":"Șterge log-urile mai vechi de X zile","default":30,"title":"Older Than Days"},"description":"Șterge log-urile mai vechi de X zile"},{"name":"level","in":"query","required":false,"schema":{"type":"string","description":"Nivelul specific (opțional)","title":"Level"},"description":"Nivelul specific (opțional)"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Clear Logs Api Logs  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/logs/stats":{"get":{"tags":["logs"],"summary":"Get Log Stats","description":"Obține statistici despre log-uri.\n\nArgs:\n    days: Numărul de zile pentru statistici\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu statisticile","operationId":"get_log_stats_api_logs_stats_get","parameters":[{"name":"days","in":"query","required":false,"schema":{"type":"integer","description":"Numărul de zile pentru statistici","default":7,"title":"Days"},"description":"Numărul de zile pentru statistici"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Log Stats Api Logs Stats Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/logs/services":{"get":{"tags":["logs"],"summary":"Get Log Services","description":"Obține lista de servicii care generează log-uri.\n\nArgs:\n    db: Sesiunea de bază de date\n    \nReturns:\n    Lista de servicii","operationId":"get_log_services_api_logs_services_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"type":"string"},"type":"array","title":"Response Get Log Services Api Logs Services Get"}}}},"404":{"description":"Not found"}}}},"/api/logs/test":{"post":{"tags":["logs"],"summary":"Create Test Log","description":"Creează un log de test.\n\nArgs:\n    level: Nivelul de log\n    message: Mesajul de log\n    service: Serviciul\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"create_test_log_api_logs_test_post","parameters":[{"name":"level","in":"query","required":false,"schema":{"type":"string","description":"Nivelul de log","default":"info","title":"Level"},"description":"Nivelul de log"},{"name":"message","in":"query","required":false,"schema":{"type":"string","description":"Mesajul de log","default":"Test log entry","title":"Message"},"description":"Mesajul de log"},{"name":"service","in":"query","required":false,"schema":{"type":"string","description":"Serviciul","default":"admin","title":"Service"},"description":"Serviciul"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Create Test Log Api Logs Test Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/health/detailed":{"get":{"summary":"Detailed Health Check","description":"Detailed health check with dependency status.\n\nReturns:\n    Dictionary with detailed health information","operationId":"detailed_health_check_health_detailed_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Detailed Health Check Health Detailed Get"}}}}}}},"/api/content/":{"get":{"tags":["content"],"summary":"List content items","operationId":"list_items_api_content__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"additionalProperties":true,"type":"object"},"type":"array","title":"Response List Items Api Content  Get"}}}}}},"post":{"tags":["content"],"summary":"Create content item","operationId":"create_item_api_content__post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CreateContentBody"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Create Item Api Content  Post"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/content/{item_id}":{"get":{"tags":["content"],"summary":"Get one content item","operationId":"get_item_api_content__item_id__get","parameters":[{"name":"item_id","in":"path","required":true,"schema":{"type":"string","title":"Item Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Item Api Content  Item Id  Get"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/content/{item_id}/validate":{"post":{"tags":["content"],"summary":"Validate item","operationId":"validate_item_api_content__item_id__validate_post","parameters":[{"name":"item_id","in":"path","required":true,"schema":{"type":"string","title":"Item Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Validate Item Api Content  Item Id  Validate Post"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/content/{item_id}/process-assets":{"post":{"tags":["content"],"summary":"Process assets (thumbs/metadata)","operationId":"process_assets_api_content__item_id__process_assets_post","parameters":[{"name":"item_id","in":"path","required":true,"schema":{"type":"string","title":"Item Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Process Assets Api Content  Item Id  Process Assets Post"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/automation/status":{"get":{"tags":["automation"],"summary":"Get Automation Status","description":"Obține statusul sistemului de automatizare.\n\nReturns:\n    Dicționar cu statusul automatizării","operationId":"get_automation_status_api_automation_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Automation Status Api Automation Status Get"}}}},"404":{"description":"Not found"}}}},"/api/automation/schedule/configure":{"post":{"tags":["automation"],"summary":"Configure Schedule","description":"Configurează programul de automatizare.","operationId":"configure_schedule_api_automation_schedule_configure_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AutomationSchedule"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Configure Schedule Api Automation Schedule Configure Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/automation/video/generate-and-post":{"post":{"tags":["automation"],"summary":"Generate And Post Video","description":"Generează și postează un video automat.","operationId":"generate_and_post_video_api_automation_video_generate_and_post_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/VideoGenerationRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Generate And Post Video Api Automation Video Generate And Post Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/automation/daily-cycle/trigger":{"post":{"tags":["automation"],"summary":"Trigger Daily Cycle","description":"Declanșează ciclul zilnic de automatizare (3 videouri).","operationId":"trigger_daily_cycle_api_automation_daily_cycle_trigger_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Trigger Daily Cycle Api Automation Daily Cycle Trigger Post"}}}},"404":{"description":"Not found"}}}},"/api/automation/performance":{"get":{"tags":["automation"],"summary":"Get Automation Performance","description":"Obține performanța sistemului de automatizare.","operationId":"get_automation_performance_api_automation_performance_get","parameters":[{"name":"days","in":"query","required":false,"schema":{"type":"integer","description":"Number of days to analyze","default":7,"title":"Days"},"description":"Number of days to analyze"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Automation Performance Api Automation Performance Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/automation/whatsapp/optimize":{"post":{"tags":["automation"],"summary":"Optimize Whatsapp Responses","description":"Optimizează răspunsurile WhatsApp Bot.","operationId":"optimize_whatsapp_responses_api_automation_whatsapp_optimize_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Optimize Whatsapp Responses Api Automation Whatsapp Optimize Post"}}}},"404":{"description":"Not found"}}}},"/api/video/queue":{"get":{"tags":["video"],"summary":"Get Video Queue","description":"Obține coada de procesare video din Supabase.\n\nArgs:\n    status: Status-ul job-urilor (opțional)\n    limit: Numărul maxim de job-uri (1-200)\n    \nReturns:\n    Dicționar cu coada de video","operationId":"get_video_queue_api_video_queue_get","parameters":[{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"$ref":"#/components/schemas/JobStatus"},{"type":"null"}],"description":"queued|processing|completed|failed|cancelled","title":"Status"},"description":"queued|processing|completed|failed|cancelled"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","maximum":200,"minimum":1,"description":"Numărul maxim de job-uri","default":50,"title":"Limit"},"description":"Numărul maxim de job-uri"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Video Queue Api Video Queue Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/retry":{"post":{"tags":["video"],"summary":"Retry Video Job","description":"Reîncearcă procesarea unui job video.\n\nArgs:\n    payload: Request payload with job_id\n    _auth: Authentication credentials\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"retry_video_job_api_video_retry_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/RetryRequest"}}},"required":true},"responses":{"202":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Retry Video Job Api Video Retry Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}},"security":[{"HTTPBearer":[]}]}},"/api/video/generate":{"post":{"tags":["video"],"summary":"Generate Video","description":"Generează un video nou.\n\nArgs:\n    video_data: Datele pentru generarea video-ului\n    _auth: Authentication credentials\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"generate_video_api_video_generate_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/VideoGenerateRequest"}}},"required":true},"responses":{"202":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Generate Video Api Video Generate Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}},"security":[{"HTTPBearer":[]}]}},"/api/video/manole-generate":{"post":{"tags":["video"],"summary":"Generate Manole Video","description":"Generează un video personalizat cu Manole ca prezentator.\n\nArgs:\n    manole_data: Datele pentru generarea video-ului Manole\n    background_tasks: Background tasks pentru procesare\n    _auth: Authentication credentials\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"generate_manole_video_api_video_manole_generate_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ManoleGenerateRequest"}}},"required":true},"responses":{"202":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Generate Manole Video Api Video Manole Generate Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}},"security":[{"HTTPBearer":[]}]}},"/api/video/stats":{"get":{"tags":["video"],"summary":"Get Video Stats","description":"Obține statistici despre procesarea video-urilor.\n\nReturns:\n    Dicționar cu statisticile","operationId":"get_video_stats_api_video_stats_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Video Stats Api Video Stats Get"}}}},"404":{"description":"Not found"}}}},"/api/video/queue/{job_id}":{"delete":{"tags":["video"],"summary":"Cancel Video Job","description":"Anulează un job video.\n\nArgs:\n    job_id: ID-ul job-ului\n    _auth: Authentication credentials\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"cancel_video_job_api_video_queue__job_id__delete","security":[{"HTTPBearer":[]}],"parameters":[{"name":"job_id","in":"path","required":true,"schema":{"type":"string","title":"Job Id"}}],"responses":{"202":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Cancel Video Job Api Video Queue  Job Id  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/manole/generate":{"post":{"tags":["video"],"summary":"Generate Manole Video","description":"Generate video with Manole talking + accident footage.\n\nThis endpoint creates a professional video by:\n1. Animating Manole's photo with Ken Burns effect\n2. Generating voice using ElevenLabs (or Edge-TTS fallback)\n3. Overlaying accident footage if provided\n4. Adding WhatsApp CTA overlay\n\nReturns video URL and metadata.","operationId":"generate_manole_video_api_video_video_manole_generate_post","requestBody":{"content":{"multipart/form-data":{"schema":{"$ref":"#/components/schemas/Body_generate_manole_video_api_video_video_manole_generate_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/batch":{"delete":{"tags":["video"],"summary":"Batch Delete Videos","description":"Delete multiple videos in batch.\n\nArgs:\n    video_ids: List of video IDs to delete\n    \nReturns:\n    Success status and count of deleted videos","operationId":"batch_delete_videos_api_video_video_batch_delete","requestBody":{"content":{"application/json":{"schema":{"items":{"type":"string"},"type":"array","title":"Video Ids"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Batch Delete Videos Api Video Video Batch Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/{video_id}":{"delete":{"tags":["video"],"summary":"Delete Video","description":"Delete a video from database and storage.\n\nArgs:\n    video_id: Video ID or job ID\n    \nReturns:\n    Deletion result","operationId":"delete_video_api_video_video__video_id__delete","parameters":[{"name":"video_id","in":"path","required":true,"schema":{"type":"string","title":"Video Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Video Api Video Video  Video Id  Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/{video_id}/download":{"get":{"tags":["video"],"summary":"Download Video","description":"Download a video file.\n\nArgs:\n    video_id: Video ID or job ID\n    \nReturns:\n    Video file for download","operationId":"download_video_api_video_video__video_id__download_get","parameters":[{"name":"video_id","in":"path","required":true,"schema":{"type":"string","title":"Video Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/{video_id}/thumbnail":{"post":{"tags":["video"],"summary":"Generate Video Thumbnail","description":"Generate thumbnail from video's first frame.\n\nArgs:\n    video_id: Video ID\n    \nReturns:\n    Thumbnail URL or base64 encoded image","operationId":"generate_video_thumbnail_api_video_video__video_id__thumbnail_post","parameters":[{"name":"video_id","in":"path","required":true,"schema":{"type":"string","title":"Video Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/heygen/generate":{"post":{"tags":["video"],"summary":"Generate Heygen Video","description":"Generează un video profesional folosind HeyGen API cu avatar vorbitor.\n\n- **script**: Textul care va fi rostit de avatar (max 1000 caractere)\n- **avatar_id**: ID avatar HeyGen (opțional, folosește default dacă lipsește)\n- **voice_id**: ID voce HeyGen (opțional)\n- **style**: Stilul video (realistic, animated, cartoon, documentary, presentation)\n- **quality**: Calitatea (low, medium, high, ultra)\n- **language**: Limba (ro, en, etc.)\n\nReturns:\n    Dict cu status, video_id și URL-ul video-ului când e gata","operationId":"generate_heygen_video_api_video_video_heygen_generate_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_generate_heygen_video_api_video_video_heygen_generate_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/heygen/status/{video_id}":{"get":{"tags":["video"],"summary":"Get Heygen Video Status","description":"Verifică statusul unui video HeyGen în curs de generare.\n\n- **video_id**: ID-ul video-ului returnat de /generate\n\nReturns:\n    Status actual și URL video când e gata","operationId":"get_heygen_video_status_api_video_video_heygen_status__video_id__get","parameters":[{"name":"video_id","in":"path","required":true,"schema":{"type":"string","title":"Video Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/video/video/heygen/avatars":{"get":{"tags":["video"],"summary":"List Heygen Avatars","description":"Listează avatarele disponibile în HeyGen.\n\nReturns:\n    Listă de avatare cu ID-uri și preview-uri","operationId":"list_heygen_avatars_api_video_video_heygen_avatars_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/conversion/track":{"post":{"tags":["conversion"],"summary":"Track Event","description":"Track a conversion event.\n\nArgs:\n    request: Event tracking data\n    \nReturns:\n    Tracking result","operationId":"track_event_api_conversion_track_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TrackEventRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Track Event Api Conversion Track Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/conversion/stats":{"get":{"tags":["conversion"],"summary":"Get Conversion Stats","description":"Get conversion statistics.\n\nArgs:\n    source: Optional source filter\n    days: Number of days to analyze\n    \nReturns:\n    Conversion statistics","operationId":"get_conversion_stats_api_conversion_stats_get","parameters":[{"name":"source","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Source"}},{"name":"days","in":"query","required":false,"schema":{"type":"integer","default":30,"title":"Days"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Conversion Stats Api Conversion Stats Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/conversion/top-sources":{"get":{"tags":["conversion"],"summary":"Get Top Sources","description":"Get top performing sources.\n\nArgs:\n    days: Number of days to analyze\n    limit: Max sources to return\n    \nReturns:\n    Top sources","operationId":"get_top_sources_api_conversion_top_sources_get","parameters":[{"name":"days","in":"query","required":false,"schema":{"type":"integer","default":30,"title":"Days"}},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","default":5,"title":"Limit"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Top Sources Api Conversion Top Sources Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/uploads":{"post":{"summary":"Upload Files","description":"Upload multiple files to Cloudflare R2 and return their URLs.\n\nEach file is stored under a unique key.  Only files with allowed\nextensions (configured via environment variables) will be uploaded.\n\n:param files: list of UploadFile objects\n:returns: dictionary with list of URLs","operationId":"upload_files_api_uploads_post","requestBody":{"content":{"multipart/form-data":{"schema":{"$ref":"#/components/schemas/Body_upload_files_api_uploads_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":{"items":{"type":"string"},"type":"array"},"type":"object","title":"Response Upload Files Api Uploads Post"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/autoposter/generate":{"post":{"summary":"Generate Video","description":"Generate a new promotional video using AI.","operationId":"generate_video_api_autoposter_generate_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Generate Video Api Autoposter Generate Post"}}}}}}},"/api/autoposter/publish":{"post":{"summary":"Publish Videos","description":"Trigger autoposter to publish pending videos.","operationId":"publish_videos_api_autoposter_publish_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Publish Videos Api Autoposter Publish Post"}}}}}}},"/api/autoposter/status":{"get":{"summary":"Get Status","description":"Get autoposter status and list of pending videos.\n\nThis endpoint uses the ``discover_videos`` function imported at\nmodule level (or its fallback) rather than importing the service\nanew. It reads the ``AUTOPOSTER_DIRECTORY`` environment variable to\ndetermine where to look for videos. When the autoposter services\nare stubbed, this simply returns an empty list.","operationId":"get_status_api_autoposter_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Status Api Autoposter Status Get"}}}}}}},"/api/notify/test":{"post":{"tags":["notifications"],"summary":"Send Test Notification","description":"Trimite o notificare de test.\n\nArgs:\n    message: Mesajul de trimis\n    background_tasks: Background tasks\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"send_test_notification_api_notify_test_post","parameters":[{"name":"message","in":"query","required":false,"schema":{"type":"string","default":"Test notificare din Admin","title":"Message"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Send Test Notification Api Notify Test Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/whatsapp":{"post":{"tags":["notifications"],"summary":"Send Whatsapp Notification","description":"Trimite o notificare pe WhatsApp Business.\n\nArgs:\n    notification_data: Datele notificării\n    background_tasks: Background tasks\n\nReturns:\n    Dicționar cu rezultatul operației","operationId":"send_whatsapp_notification_api_notify_whatsapp_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Notification Data"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Send Whatsapp Notification Api Notify Whatsapp Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/email":{"post":{"tags":["notifications"],"summary":"Send Email Notification","description":"Trimite o notificare prin email.\n\nArgs:\n    notification_data: Datele notificării\n    background_tasks: Background tasks\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu rezultatul operației","operationId":"send_email_notification_api_notify_email_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Notification Data"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Send Email Notification Api Notify Email Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/status":{"get":{"tags":["notifications"],"summary":"Get Notification Status","description":"Obține statusul serviciilor de notificare.\n\nArgs:\n    db: Sesiunea de bază de date\n    \nReturns:\n    Dicționar cu statusul serviciilor","operationId":"get_notification_status_api_notify_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Notification Status Api Notify Status Get"}}}},"404":{"description":"Not found"}}}},"/api/notify/list":{"get":{"tags":["notifications"],"summary":"Get Notifications","description":"Obține lista de notificări pentru user.\n\nReturns:\n    Listă cu notificări și count-uri","operationId":"get_notifications_api_notify_list_get","parameters":[{"name":"unread_only","in":"query","required":false,"schema":{"type":"boolean","description":"Doar notificări necitite","default":false,"title":"Unread Only"},"description":"Doar notificări necitite"},{"name":"limit","in":"query","required":false,"schema":{"type":"integer","description":"Număr maxim de notificări","default":20,"title":"Limit"},"description":"Număr maxim de notificări"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Get Notifications Api Notify List Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/mark-read/{notification_id}":{"post":{"tags":["notifications"],"summary":"Mark Notification As Read","description":"Marchează o notificare ca citită.\n\nArgs:\n    notification_id: ID-ul notificării\n    \nReturns:\n    Success message","operationId":"mark_notification_as_read_api_notify_mark_read__notification_id__post","parameters":[{"name":"notification_id","in":"path","required":true,"schema":{"type":"string","title":"Notification Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Mark Notification As Read Api Notify Mark Read  Notification Id  Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/email-templates":{"get":{"tags":["notifications"],"summary":"Get Email Templates","description":"Get available email templates for notifications.\n\nReturns:\n    List of email templates","operationId":"get_email_templates_api_notify_email_templates_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Email Templates Api Notify Email Templates Get"}}}},"404":{"description":"Not found"}}}},"/api/notify/email-template":{"post":{"tags":["notifications"],"summary":"Send Email With Template","description":"Send email using a template with variables.\n\nArgs:\n    template_id: ID of the email template\n    recipient_email: Email address of recipient\n    variables: JSON string with template variables\n    background_tasks: Background tasks\n    \nReturns:\n    Success message","operationId":"send_email_with_template_api_notify_email_template_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_send_email_with_template_api_notify_email_template_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Send Email With Template Api Notify Email Template Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/email-settings":{"get":{"tags":["notifications"],"summary":"Get Email Settings","description":"Get email notification settings.\n\nReturns:\n    Email settings configuration","operationId":"get_email_settings_api_notify_email_settings_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Email Settings Api Notify Email Settings Get"}}}},"404":{"description":"Not found"}}},"post":{"tags":["notifications"],"summary":"Update Email Settings","description":"Update email notification settings.\n\nArgs:\n    settings: Email settings to update\n    \nReturns:\n    Success message","operationId":"update_email_settings_api_notify_email_settings_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Settings"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Update Email Settings Api Notify Email Settings Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/test-template":{"post":{"tags":["notifications"],"summary":"Test Email Template","description":"Send test email using a template.\n\nArgs:\n    template_id: ID of the email template\n    test_email: Email address to send test to\n    background_tasks: Background tasks\n    \nReturns:\n    Success message","operationId":"test_email_template_api_notify_test_template_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_test_email_template_api_notify_test_template_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Test Email Template Api Notify Test Template Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/sms":{"post":{"tags":["notifications"],"summary":"Send Sms Notification","description":"Send SMS notification.\n\nArgs:\n    phone_number: Phone number to send SMS to\n    message: SMS message content\n    template_id: Optional SMS template ID\n    variables: JSON string with template variables\n    background_tasks: Background tasks\n    \nReturns:\n    Success message","operationId":"send_sms_notification_api_notify_sms_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_send_sms_notification_api_notify_sms_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Send Sms Notification Api Notify Sms Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/sms-templates":{"get":{"tags":["notifications"],"summary":"Get Sms Templates","description":"Get available SMS templates.\n\nReturns:\n    List of SMS templates","operationId":"get_sms_templates_api_notify_sms_templates_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Sms Templates Api Notify Sms Templates Get"}}}},"404":{"description":"Not found"}}}},"/api/notify/sms-template":{"post":{"tags":["notifications"],"summary":"Send Sms With Template","description":"Send SMS using a template with variables.\n\nArgs:\n    template_id: ID of the SMS template\n    phone_number: Phone number to send SMS to\n    variables: JSON string with template variables\n    background_tasks: Background tasks\n    \nReturns:\n    Success message","operationId":"send_sms_with_template_api_notify_sms_template_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_send_sms_with_template_api_notify_sms_template_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Send Sms With Template Api Notify Sms Template Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/sms-settings":{"get":{"tags":["notifications"],"summary":"Get Sms Settings","description":"Get SMS notification settings.\n\nReturns:\n    SMS settings configuration","operationId":"get_sms_settings_api_notify_sms_settings_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Get Sms Settings Api Notify Sms Settings Get"}}}},"404":{"description":"Not found"}}},"post":{"tags":["notifications"],"summary":"Update Sms Settings","description":"Update SMS notification settings.\n\nArgs:\n    settings: SMS settings to update\n    \nReturns:\n    Success message","operationId":"update_sms_settings_api_notify_sms_settings_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Settings"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Update Sms Settings Api Notify Sms Settings Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/notify/test-sms":{"post":{"tags":["notifications"],"summary":"Test Sms Notification","description":"Send test SMS notification.\n\nArgs:\n    phone_number: Phone number to send test SMS to\n    test_message: Test message content\n    background_tasks: Background tasks\n    \nReturns:\n    Success message","operationId":"test_sms_notification_api_notify_test_sms_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_test_sms_notification_api_notify_test_sms_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Test Sms Notification Api Notify Test Sms Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/whatsapp/webhook":{"post":{"tags":["whatsapp"],"summary":"Whatsapp Webhook","description":"Handle incoming WhatsApp webhook events.","operationId":"whatsapp_webhook_api_whatsapp_webhook_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Whatsapp Webhook Api Whatsapp Webhook Post"}}}},"404":{"description":"Not found"}}}},"/api/whatsapp/send":{"post":{"tags":["whatsapp"],"summary":"Whatsapp Send","description":"Send an outbound WhatsApp message to a user.\n\nBody minim: {\"to\":\"+407...\",\"message\":\"text\"}","operationId":"whatsapp_send_api_whatsapp_send_post","requestBody":{"content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Data"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":true,"type":"object","title":"Response Whatsapp Send Api Whatsapp Send Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/simple-video/generate":{"post":{"tags":["simple-video"],"summary":"Generate Simple Video","description":"Generate a simple video with text overlay.","operationId":"generate_simple_video_api_simple_video_generate_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SimpleVideoRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/VideoResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/simple-video/list":{"get":{"tags":["simple-video"],"summary":"List Generated Videos","description":"List all generated videos and demo files.","operationId":"list_generated_videos_api_simple_video_list_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/simple-video/create-demo":{"post":{"tags":["simple-video"],"summary":"Create Demo File","description":"Create a simple demo file to prove the endpoint works.","operationId":"create_demo_file_api_simple_video_create_demo_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/simple-video/test":{"get":{"tags":["simple-video"],"summary":"Test Video Capabilities","description":"Test video generation capabilities.","operationId":"test_video_capabilities_api_simple_video_test_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/working-automation/status":{"get":{"tags":["working-automation"],"summary":"Get Automation Status","description":"Get current automation status with real data.","operationId":"get_automation_status_api_working_automation_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/working-automation/toggle":{"post":{"tags":["working-automation"],"summary":"Toggle Automation","description":"Toggle automation on/off - ACTUALLY WORKS!","operationId":"toggle_automation_api_working_automation_toggle_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AutomationToggleRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/working-automation/update-schedule":{"post":{"tags":["working-automation"],"summary":"Update Schedule","description":"Update posting schedule - ACTUALLY WORKS!","operationId":"update_schedule_api_working_automation_update_schedule_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ScheduleUpdateRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/working-automation/trigger-post":{"post":{"tags":["working-automation"],"summary":"Trigger Manual Post","description":"Manually trigger a post - ACTUALLY WORKS!","operationId":"trigger_manual_post_api_working_automation_trigger_post_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/working-automation/recent-actions":{"get":{"tags":["working-automation"],"summary":"Get Recent Actions","description":"Get recent automation actions.","operationId":"get_recent_actions_api_working_automation_recent_actions_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/working-automation/reset-daily-count":{"post":{"tags":["working-automation"],"summary":"Reset Daily Post Count","description":"Reset daily post counter - useful for testing.","operationId":"reset_daily_post_count_api_working_automation_reset_daily_count_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/professional-video/generate":{"post":{"tags":["professional-video"],"summary":"Generate Professional Video","description":"Generate professional AI video with avatar, lip sync, and backgrounds.","operationId":"generate_professional_video_api_professional_video_generate_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProfessionalVideoRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProfessionalVideoResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/professional-video/avatars":{"get":{"tags":["professional-video"],"summary":"List Available Avatars","description":"List available avatar styles.","operationId":"list_available_avatars_api_professional_video_avatars_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/professional-video/backgrounds":{"get":{"tags":["professional-video"],"summary":"List Available Backgrounds","description":"List available background styles.","operationId":"list_available_backgrounds_api_professional_video_backgrounds_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/professional-video/test-capabilities":{"get":{"tags":["professional-video"],"summary":"Test Professional Video Capabilities","description":"Test professional video generation capabilities.","operationId":"test_professional_video_capabilities_api_professional_video_test_capabilities_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/advanced-video/generate":{"post":{"tags":["advanced-video"],"summary":"Generate Advanced Video","description":"Generate advanced professional video with AI avatar and backgrounds.","operationId":"generate_advanced_video_api_advanced_video_generate_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AdvancedVideoRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AdvancedVideoResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/advanced-video/preview/{filename}":{"get":{"tags":["advanced-video"],"summary":"Get Video Preview","description":"Get generated video preview.","operationId":"get_video_preview_api_advanced_video_preview__filename__get","parameters":[{"name":"filename","in":"path","required":true,"schema":{"type":"string","title":"Filename"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/advanced-video/list-generated":{"get":{"tags":["advanced-video"],"summary":"List Generated Videos","description":"List all generated advanced videos and previews.","operationId":"list_generated_videos_api_advanced_video_list_generated_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/advanced-video/capabilities":{"get":{"tags":["advanced-video"],"summary":"Get Advanced Capabilities","description":"Get advanced video generation capabilities.","operationId":"get_advanced_capabilities_api_advanced_video_capabilities_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"404":{"description":"Not found"}}}},"/api/growth-engine/generate-mass-content":{"post":{"tags":["Growth Engine"],"summary":"Generate Mass Content","description":"Generate viral content at massive scale for simultaneous growth","operationId":"generate_mass_content_api_growth_engine_generate_mass_content_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MassContentRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/growth-engine/growth-analytics":{"get":{"tags":["Growth Engine"],"summary":"Get Growth Analytics","description":"Get real-time growth analytics and performance metrics","operationId":"get_growth_analytics_api_growth_engine_growth_analytics_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-engine/viral-boost":{"post":{"tags":["Growth Engine"],"summary":"Activate Viral Boost","description":"Activate emergency viral content boost for maximum growth","operationId":"activate_viral_boost_api_growth_engine_viral_boost_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-engine/growth-status":{"get":{"tags":["Growth Engine"],"summary":"Get Growth Status","description":"Get current growth engine status","operationId":"get_growth_status_api_growth_engine_growth_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/intelligent-conversion/analyze-lead":{"post":{"tags":["Intelligent Conversion"],"summary":"Analyze Lead Intelligence","description":"Analyze lead with AI and generate conversion strategy","operationId":"analyze_lead_intelligence_api_intelligent_conversion_analyze_lead_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/LeadProfile"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/intelligent-conversion/execute-conversion-actions":{"post":{"tags":["Intelligent Conversion"],"summary":"Execute Conversion Actions","description":"Execute automated conversion actions for a lead","operationId":"execute_conversion_actions_api_intelligent_conversion_execute_conversion_actions_post","parameters":[{"name":"lead_id","in":"query","required":true,"schema":{"type":"string","title":"Lead Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/intelligent-conversion/conversion-analytics":{"get":{"tags":["Intelligent Conversion"],"summary":"Get Conversion Analytics","description":"Get intelligent conversion analytics","operationId":"get_conversion_analytics_api_intelligent_conversion_conversion_analytics_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/intelligent-conversion/mass-lead-processing":{"post":{"tags":["Intelligent Conversion"],"summary":"Process Leads At Scale","description":"Process all leads with intelligent conversion system","operationId":"process_leads_at_scale_api_intelligent_conversion_mass_lead_processing_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/intelligent-conversion/system-status":{"get":{"tags":["Intelligent Conversion"],"summary":"Get Conversion System Status","description":"Get intelligent conversion system status","operationId":"get_conversion_system_status_api_intelligent_conversion_system_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/customer-nurturing/start-nurturing-journey":{"post":{"tags":["Customer Nurturing"],"summary":"Start Customer Nurturing","description":"Start automated customer nurturing journey","operationId":"start_customer_nurturing_api_customer_nurturing_start_nurturing_journey_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CustomerProfile"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/customer-nurturing/mass-nurturing-activation":{"post":{"tags":["Customer Nurturing"],"summary":"Activate Mass Nurturing","description":"Activate mass nurturing for all customers","operationId":"activate_mass_nurturing_api_customer_nurturing_mass_nurturing_activation_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/customer-nurturing/nurturing-analytics":{"get":{"tags":["Customer Nurturing"],"summary":"Get Nurturing Analytics","description":"Get comprehensive nurturing analytics","operationId":"get_nurturing_analytics_api_customer_nurturing_nurturing_analytics_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/customer-nurturing/optimize-nurturing":{"post":{"tags":["Customer Nurturing"],"summary":"Optimize Nurturing Campaigns","description":"AI-powered nurturing optimization","operationId":"optimize_nurturing_campaigns_api_customer_nurturing_optimize_nurturing_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/customer-nurturing/customer-journey-map":{"get":{"tags":["Customer Nurturing"],"summary":"Get Customer Journey Map","description":"Get visual customer journey mapping","operationId":"get_customer_journey_map_api_customer_nurturing_customer_journey_map_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/customer-nurturing/nurturing-system-status":{"get":{"tags":["Customer Nurturing"],"summary":"Get Nurturing System Status","description":"Get customer nurturing system status","operationId":"get_nurturing_system_status_api_customer_nurturing_nurturing_system_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/affiliate-multiplication/create-affiliate":{"post":{"tags":["Affiliate Multiplication"],"summary":"Create Affiliate Account","description":"Create new affiliate account with viral tracking","operationId":"create_affiliate_account_api_affiliate_multiplication_create_affiliate_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AffiliateProfile"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/affiliate-multiplication/process-referral":{"post":{"tags":["Affiliate Multiplication"],"summary":"Process Viral Referral","description":"Process referral with viral multiplication tracking","operationId":"process_viral_referral_api_affiliate_multiplication_process_referral_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ReferralRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/affiliate-multiplication/affiliate-leaderboard":{"get":{"tags":["Affiliate Multiplication"],"summary":"Get Affiliate Leaderboard","description":"Get top performing affiliates leaderboard","operationId":"get_affiliate_leaderboard_api_affiliate_multiplication_affiliate_leaderboard_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/affiliate-multiplication/viral-boost-campaign":{"post":{"tags":["Affiliate Multiplication"],"summary":"Launch Viral Boost Campaign","description":"Launch viral boost campaign for explosive growth","operationId":"launch_viral_boost_campaign_api_affiliate_multiplication_viral_boost_campaign_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/affiliate-multiplication/viral-analytics":{"get":{"tags":["Affiliate Multiplication"],"summary":"Get Viral Growth Analytics","description":"Get comprehensive viral growth analytics","operationId":"get_viral_growth_analytics_api_affiliate_multiplication_viral_analytics_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/affiliate-multiplication/affiliate-system-status":{"get":{"tags":["Affiliate Multiplication"],"summary":"Get Affiliate System Status","description":"Get affiliate multiplication system status","operationId":"get_affiliate_system_status_api_affiliate_multiplication_affiliate_system_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/dashboard":{"get":{"tags":["Growth Analytics"],"summary":"Get Comprehensive Growth Dashboard","description":"Get comprehensive growth analytics dashboard","operationId":"get_comprehensive_growth_dashboard_api_growth_analytics_dashboard_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/real-time-metrics":{"get":{"tags":["Growth Analytics"],"summary":"Get Real Time Growth Metrics","description":"Get real-time growth metrics across all systems","operationId":"get_real_time_growth_metrics_api_growth_analytics_real_time_metrics_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/growth-projections":{"get":{"tags":["Growth Analytics"],"summary":"Get Growth Projections","description":"Get AI-powered growth projections and forecasting","operationId":"get_growth_projections_api_growth_analytics_growth_projections_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/competitive-intelligence":{"get":{"tags":["Growth Analytics"],"summary":"Get Competitive Intelligence","description":"Get competitive intelligence and market positioning","operationId":"get_competitive_intelligence_api_growth_analytics_competitive_intelligence_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/optimization-recommendations":{"get":{"tags":["Growth Analytics"],"summary":"Get Optimization Recommendations","description":"Get AI-powered optimization recommendations","operationId":"get_optimization_recommendations_api_growth_analytics_optimization_recommendations_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/roi-analysis":{"get":{"tags":["Growth Analytics"],"summary":"Get Roi Analysis","description":"Get comprehensive ROI analysis of all growth systems","operationId":"get_roi_analysis_api_growth_analytics_roi_analysis_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/growth-health-score":{"get":{"tags":["Growth Analytics"],"summary":"Get Growth Health Score","description":"Get comprehensive growth health score and system status","operationId":"get_growth_health_score_api_growth_analytics_growth_health_score_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/growth-analytics/system-status":{"get":{"tags":["Growth Analytics"],"summary":"Get Growth Analytics Status","description":"Get growth analytics system status","operationId":"get_growth_analytics_status_api_growth_analytics_system_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/master-growth/activate-explosive-growth":{"post":{"tags":["Master Growth Activation"],"summary":"Activate Explosive Growth","description":"🚀 ACTIVATE EXPLOSIVE SIMULTANEOUS GROWTH ACROSS ALL SYSTEMS","operationId":"activate_explosive_growth_api_master_growth_activate_explosive_growth_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/GrowthActivationRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/master-growth/system-overview":{"get":{"tags":["Master Growth Activation"],"summary":"Get Master System Overview","description":"Get complete overview of the master growth system","operationId":"get_master_system_overview_api_master_growth_system_overview_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/master-growth/activation-status":{"get":{"tags":["Master Growth Activation"],"summary":"Get Activation Status","description":"Get current activation status of all growth systems","operationId":"get_activation_status_api_master_growth_activation_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/master-growth/emergency-scale-up":{"post":{"tags":["Master Growth Activation"],"summary":"Emergency Scale Up","description":"🚨 EMERGENCY SCALE-UP - Maximum growth activation","operationId":"emergency_scale_up_api_master_growth_emergency_scale_up_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/master-growth/growth-ecosystem-summary":{"get":{"tags":["Master Growth Activation"],"summary":"Get Growth Ecosystem Summary","description":"Get complete summary of the growth ecosystem built","operationId":"get_growth_ecosystem_summary_api_master_growth_growth_ecosystem_summary_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/master-growth/master-status":{"get":{"tags":["Master Growth Activation"],"summary":"Get Master System Status","description":"Get master growth system status","operationId":"get_master_system_status_api_master_growth_master_status_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/":{"get":{"summary":"Root","operationId":"root__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"additionalProperties":{"type":"string"},"type":"object","title":"Response Root  Get"}}}}}}}},"components":{"schemas":{"AdvancedVideoRequest":{"properties":{"text":{"type":"string","title":"Text","default":"AutoPro Daune - Experții în daune auto. Soluții rapide și profesionale pentru toate nevoile tale!"},"duration":{"type":"integer","title":"Duration","default":15},"resolution":{"type":"string","title":"Resolution","default":"1080p"},"aspect_ratio":{"type":"string","title":"Aspect Ratio","default":"portrait"},"avatar_id":{"type":"string","title":"Avatar Id","default":"professional"},"background_id":{"type":"string","title":"Background Id","default":"office"},"voice_language":{"type":"string","title":"Voice Language","default":"romanian"},"voice_gender":{"type":"string","title":"Voice Gender","default":"female"},"enable_subtitles":{"type":"boolean","title":"Enable Subtitles","default":true},"enable_lip_sync":{"type":"boolean","title":"Enable Lip Sync","default":true},"custom_background_color":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Custom Background Color","default":"#1a73e8"},"text_position":{"type":"string","title":"Text Position","default":"left"}},"type":"object","title":"AdvancedVideoRequest"},"AdvancedVideoResponse":{"properties":{"success":{"type":"boolean","title":"Success"},"message":{"type":"string","title":"Message"},"video_preview_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Video Preview Path"},"video_config_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Video Config Path"},"preview_image_base64":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Preview Image Base64"},"generation_specs":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Generation Specs"},"estimated_generation_time":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Estimated Generation Time"}},"type":"object","required":["success","message"],"title":"AdvancedVideoResponse"},"AffiliateProfile":{"properties":{"affiliate_id":{"type":"string","title":"Affiliate Id"},"name":{"type":"string","title":"Name"},"email":{"type":"string","title":"Email"},"phone":{"type":"string","title":"Phone"},"tier":{"type":"string","title":"Tier","default":"bronze"},"referral_count":{"type":"integer","title":"Referral Count","default":0},"total_earnings":{"type":"number","title":"Total Earnings","default":0.0},"conversion_rate":{"type":"number","title":"Conversion Rate","default":0.0},"social_reach":{"type":"integer","title":"Social Reach","default":0},"specialties":{"items":{"type":"string"},"type":"array","title":"Specialties","default":[]}},"type":"object","required":["affiliate_id","name","email","phone"],"title":"AffiliateProfile"},"AutomationSchedule":{"properties":{"enabled":{"type":"boolean","title":"Enabled","default":true},"posting_times":{"items":{"type":"string"},"type":"array","title":"Posting Times","default":["09:00","15:00","21:00"]},"platforms":{"items":{"type":"string"},"type":"array","title":"Platforms","default":["tiktok","facebook","instagram"]},"content_types":{"items":{"type":"string"},"type":"array","title":"Content Types","default":["educational","testimonial","promotional"]}},"type":"object","title":"AutomationSchedule"},"AutomationToggleRequest":{"properties":{"active":{"type":"boolean","title":"Active"}},"type":"object","required":["active"],"title":"AutomationToggleRequest"},"Body_bulk_update_leads_api_leads_bulk_update_post":{"properties":{"lead_ids":{"items":{"type":"string"},"type":"array","title":"Lead Ids"},"updates":{"additionalProperties":true,"type":"object","title":"Updates"}},"type":"object","required":["lead_ids","updates"],"title":"Body_bulk_update_leads_api_leads_bulk_update_post"},"Body_create_budget_plan_api_financial_budget_plans_post":{"properties":{"name":{"type":"string","title":"Name"},"description":{"type":"string","title":"Description"},"period":{"type":"string","title":"Period"},"start_date":{"type":"string","title":"Start Date"},"end_date":{"type":"string","title":"End Date"},"categories":{"type":"string","title":"Categories"}},"type":"object","required":["name","description","period","start_date","end_date","categories"],"title":"Body_create_budget_plan_api_financial_budget_plans_post"},"Body_create_invoice_api_financial_invoices_post":{"properties":{"client_name":{"type":"string","title":"Client Name"},"client_email":{"type":"string","title":"Client Email"},"client_address":{"type":"string","title":"Client Address"},"due_date":{"type":"string","title":"Due Date"},"tax_rate":{"type":"number","title":"Tax Rate","default":0.19},"items":{"type":"string","title":"Items"},"notes":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Notes"}},"type":"object","required":["client_name","client_email","client_address","due_date","items"],"title":"Body_create_invoice_api_financial_invoices_post"},"Body_create_payment_api_financial_payments_post":{"properties":{"invoice_id":{"type":"string","title":"Invoice Id"},"amount":{"type":"number","title":"Amount"},"payment_method":{"type":"string","title":"Payment Method"},"payment_date":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Payment Date"},"reference":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Reference"},"notes":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Notes"}},"type":"object","required":["invoice_id","amount","payment_method"],"title":"Body_create_payment_api_financial_payments_post"},"Body_generate_heygen_video_api_video_video_heygen_generate_post":{"properties":{"script":{"type":"string","title":"Script","description":"Textul pentru video (max 1000 caractere)"},"avatar_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Avatar Id","description":"ID-ul avatarului HeyGen"},"voice_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Voice Id","description":"ID-ul vocii"},"style":{"type":"string","title":"Style","description":"Stilul video: realistic, animated, cartoon, documentary, presentation","default":"realistic"},"quality":{"type":"string","title":"Quality","description":"Calitatea video: low, medium, high, ultra","default":"high"},"language":{"type":"string","title":"Language","description":"Limba pentru voice-over","default":"ro"}},"type":"object","required":["script"],"title":"Body_generate_heygen_video_api_video_video_heygen_generate_post"},"Body_generate_manole_video_api_video_video_manole_generate_post":{"properties":{"prompt":{"type":"string","title":"Prompt","description":"Script prompt for the video"},"manole_photo":{"type":"string","format":"binary","title":"Manole Photo","description":"Manole's photo to animate"},"accident_footage":{"anyOf":[{"items":{"type":"string","format":"binary"},"type":"array"},{"type":"null"}],"title":"Accident Footage","description":"Accident photos/videos (optional)"},"display_mode":{"type":"string","title":"Display Mode","description":"Display mode: sequence, pip, or split","default":"sequence"},"voice_emotion":{"type":"string","title":"Voice Emotion","description":"Voice emotion: professional, empathetic, or urgent","default":"professional"}},"type":"object","required":["prompt","manole_photo"],"title":"Body_generate_manole_video_api_video_video_manole_generate_post"},"Body_send_email_to_lead_api_leads__lead_id__send_email_post":{"properties":{"subject":{"type":"string","title":"Subject"},"message":{"type":"string","title":"Message"},"template":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Template"}},"type":"object","required":["subject","message"],"title":"Body_send_email_to_lead_api_leads__lead_id__send_email_post"},"Body_send_email_with_template_api_notify_email_template_post":{"properties":{"template_id":{"type":"string","title":"Template Id"},"recipient_email":{"type":"string","title":"Recipient Email"},"variables":{"type":"string","title":"Variables"}},"type":"object","required":["template_id","recipient_email","variables"],"title":"Body_send_email_with_template_api_notify_email_template_post"},"Body_send_sms_notification_api_notify_sms_post":{"properties":{"phone_number":{"type":"string","title":"Phone Number"},"message":{"type":"string","title":"Message"},"template_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Template Id"},"variables":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Variables"}},"type":"object","required":["phone_number","message"],"title":"Body_send_sms_notification_api_notify_sms_post"},"Body_send_sms_with_template_api_notify_sms_template_post":{"properties":{"template_id":{"type":"string","title":"Template Id"},"phone_number":{"type":"string","title":"Phone Number"},"variables":{"type":"string","title":"Variables"}},"type":"object","required":["template_id","phone_number","variables"],"title":"Body_send_sms_with_template_api_notify_sms_template_post"},"Body_test_email_template_api_notify_test_template_post":{"properties":{"template_id":{"type":"string","title":"Template Id"},"test_email":{"type":"string","title":"Test Email"}},"type":"object","required":["template_id","test_email"],"title":"Body_test_email_template_api_notify_test_template_post"},"Body_test_sms_notification_api_notify_test_sms_post":{"properties":{"phone_number":{"type":"string","title":"Phone Number"},"test_message":{"type":"string","title":"Test Message","default":"Test SMS din AutoPro Daune"}},"type":"object","required":["phone_number"],"title":"Body_test_sms_notification_api_notify_test_sms_post"},"Body_upload_files_api_uploads_post":{"properties":{"files":{"items":{"type":"string","format":"binary"},"type":"array","title":"Files"}},"type":"object","required":["files"],"title":"Body_upload_files_api_uploads_post"},"Body_upload_lead_attachment_api_leads_upload_attachment_post":{"properties":{"file":{"type":"string","format":"binary","title":"File"},"lead_id":{"type":"string","title":"Lead Id"}},"type":"object","required":["file","lead_id"],"title":"Body_upload_lead_attachment_api_leads_upload_attachment_post"},"Body_upload_video_for_posting_api_social_upload_video_post":{"properties":{"video":{"type":"string","format":"binary","title":"Video"},"caption":{"type":"string","title":"Caption"},"platforms":{"type":"string","title":"Platforms"},"scheduled_for":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Scheduled For"}},"type":"object","required":["video","caption","platforms"],"title":"Body_upload_video_for_posting_api_social_upload_video_post"},"BudgetAlertCreate":{"properties":{"alert_name":{"type":"string","maxLength":100,"minLength":1,"title":"Alert Name","description":"Numele alertei"},"alert_type":{"type":"string","maxLength":50,"minLength":1,"title":"Alert Type","description":"Tipul alertei"},"threshold_value":{"anyOf":[{"type":"number"},{"type":"string"}],"title":"Threshold Value","description":"Valoarea pragului"},"message":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Message","description":"Mesajul alertei"},"is_active":{"type":"boolean","title":"Is Active","description":"Dacă alerta este activă","default":true}},"type":"object","required":["alert_name","alert_type","threshold_value"],"title":"BudgetAlertCreate","description":"Schema pentru crearea unei alerte de buget."},"BudgetAlertResponse":{"properties":{"id":{"type":"integer","title":"Id"},"alert_name":{"type":"string","title":"Alert Name"},"alert_type":{"type":"string","title":"Alert Type"},"threshold_value":{"type":"string","title":"Threshold Value"},"current_value":{"type":"string","title":"Current Value"},"is_triggered":{"type":"boolean","title":"Is Triggered"},"is_active":{"type":"boolean","title":"Is Active"},"message":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Message"},"notification_sent":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"Notification Sent"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["id","alert_name","alert_type","threshold_value","current_value","is_triggered","is_active","message","notification_sent","created_at","updated_at"],"title":"BudgetAlertResponse","description":"Schema pentru răspunsul cu date despre alertă."},"CampaignMetricsCreate":{"properties":{"campaign_name":{"type":"string","maxLength":100,"minLength":1,"title":"Campaign Name","description":"Numele campaniei"},"platform":{"type":"string","maxLength":50,"minLength":1,"title":"Platform","description":"Platforma (ex: TikTok, Instagram)"},"period_start":{"type":"string","format":"date","title":"Period Start","description":"Începutul perioadei"},"period_end":{"type":"string","format":"date","title":"Period End","description":"Sfârșitul perioadei"},"metadata":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Metadata","description":"Metadata suplimentară"}},"type":"object","required":["campaign_name","platform","period_start","period_end"],"title":"CampaignMetricsCreate","description":"Schema pentru crearea metricilor de campanie."},"CampaignMetricsResponse":{"properties":{"id":{"type":"integer","title":"Id"},"campaign_name":{"type":"string","title":"Campaign Name"},"platform":{"type":"string","title":"Platform"},"period_start":{"type":"string","format":"date","title":"Period Start"},"period_end":{"type":"string","format":"date","title":"Period End"},"total_spent":{"type":"string","title":"Total Spent"},"cost_per_lead":{"type":"string","title":"Cost Per Lead"},"cost_per_conversion":{"type":"string","title":"Cost Per Conversion"},"total_leads":{"type":"integer","title":"Total Leads"},"total_conversions":{"type":"integer","title":"Total Conversions"},"conversion_rate":{"type":"string","title":"Conversion Rate"},"total_views":{"type":"integer","title":"Total Views"},"total_likes":{"type":"integer","title":"Total Likes"},"total_shares":{"type":"integer","title":"Total Shares"},"engagement_rate":{"type":"string","title":"Engagement Rate"},"total_revenue":{"type":"string","title":"Total Revenue"},"net_profit":{"type":"string","title":"Net Profit"},"roi_percentage":{"type":"string","title":"Roi Percentage"},"metadata":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Metadata"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["id","campaign_name","platform","period_start","period_end","total_spent","cost_per_lead","cost_per_conversion","total_leads","total_conversions","conversion_rate","total_views","total_likes","total_shares","engagement_rate","total_revenue","net_profit","roi_percentage","metadata","created_at","updated_at"],"title":"CampaignMetricsResponse","description":"Schema pentru răspunsul cu metrici de campanie."},"ContentCategory":{"type":"string","enum":["automotive","insurance","education","promotional","informational","entertainment"],"title":"ContentCategory"},"ContentType":{"type":"string","enum":["video","image","carousel","text"],"title":"ContentType","description":"Tipurile de conținut suportate."},"CreateContentBody":{"properties":{"title":{"type":"string","title":"Title"},"description":{"type":"string","title":"Description","default":""},"category":{"$ref":"#/components/schemas/ContentCategory","default":"informational"},"content_type":{"$ref":"#/components/schemas/ContentType","default":"image"},"assets":{"items":{"type":"string"},"type":"array","title":"Assets"},"target_platforms":{"items":{"type":"string"},"type":"array","title":"Target Platforms"},"metadata":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Metadata"}},"type":"object","required":["title"],"title":"CreateContentBody"},"CreditBalanceResponse":{"properties":{"id":{"type":"integer","title":"Id"},"provider":{"type":"string","title":"Provider"},"credit_type":{"type":"string","title":"Credit Type"},"current_balance":{"type":"string","title":"Current Balance"},"total_allocated":{"type":"string","title":"Total Allocated"},"last_updated":{"type":"string","format":"date-time","title":"Last Updated"},"usage_percentage":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Usage Percentage"},"remaining_credits":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Remaining Credits"}},"type":"object","required":["id","provider","credit_type","current_balance","total_allocated","last_updated"],"title":"CreditBalanceResponse","description":"Schema pentru răspunsul cu soldul creditelor."},"CustomerProfile":{"properties":{"customer_id":{"type":"string","title":"Customer Id"},"name":{"type":"string","title":"Name"},"email":{"type":"string","title":"Email"},"phone":{"type":"string","title":"Phone"},"current_stage":{"type":"string","title":"Current Stage","default":"awareness"},"join_date":{"type":"string","title":"Join Date"},"interaction_history":{"items":{"additionalProperties":true,"type":"object"},"type":"array","title":"Interaction History","default":[]},"preferences":{"additionalProperties":true,"type":"object","title":"Preferences","default":{}},"lifetime_value":{"type":"number","title":"Lifetime Value","default":0.0}},"type":"object","required":["customer_id","name","email","phone","join_date"],"title":"CustomerProfile"},"GrowthActivationRequest":{"properties":{"activation_level":{"type":"string","title":"Activation Level","default":"explosive"},"target_timeframe":{"type":"string","title":"Target Timeframe","default":"30_days"},"growth_multiplier":{"type":"number","title":"Growth Multiplier","default":10.0},"budget_limit":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Budget Limit"},"focus_areas":{"items":{"type":"string"},"type":"array","title":"Focus Areas","default":["all"]}},"type":"object","title":"GrowthActivationRequest"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"JobStatus":{"type":"string","enum":["queued","processing","completed","failed","cancelled"],"title":"JobStatus"},"LeadActivityCreate":{"properties":{"activity_type":{"type":"string","title":"Activity Type","description":"Type: note, email, call, sms, meeting, status_change"},"title":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Title"},"description":{"type":"string","title":"Description"},"metadata":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Metadata","default":{}},"performed_by":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Performed By","default":"system"}},"type":"object","required":["activity_type","description"],"title":"LeadActivityCreate"},"LeadCreate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"phone_number":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Phone Number"},"email":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Email"},"source":{"type":"string","title":"Source","description":"Lead source: tiktok, facebook, instagram, whatsapp, referral, direct"},"lead_type":{"type":"string","title":"Lead Type","description":"Type of lead","default":"crash_claim"},"status":{"type":"string","title":"Status","description":"Lead status","default":"new"},"details":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Details"},"notes":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Notes"},"estimated_value":{"anyOf":[{"type":"number","minimum":0.0},{"type":"null"}],"title":"Estimated Value","default":0},"priority":{"type":"string","title":"Priority","description":"Priority: low, medium, high","default":"medium"}},"type":"object","required":["source"],"title":"LeadCreate"},"LeadProfile":{"properties":{"lead_id":{"type":"string","title":"Lead Id"},"contact_info":{"additionalProperties":true,"type":"object","title":"Contact Info"},"interaction_history":{"items":{"additionalProperties":true,"type":"object"},"type":"array","title":"Interaction History"},"damage_details":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Damage Details"},"urgency_level":{"type":"string","title":"Urgency Level","default":"medium"},"source":{"type":"string","title":"Source","default":"unknown"}},"type":"object","required":["lead_id","contact_info","interaction_history"],"title":"LeadProfile"},"ManoleGenerateRequest":{"properties":{"topic":{"type":"string","title":"Topic"},"duration_seconds":{"type":"integer","title":"Duration Seconds"},"resolution":{"type":"string","enum":["720p","1080p","4k"],"title":"Resolution","default":"1080p"},"bg_type":{"type":"string","enum":["color","image"],"title":"Bg Type","default":"color"},"bg_value":{"type":"string","title":"Bg Value"},"voice_mode":{"type":"string","title":"Voice Mode","default":"romanian_tts"},"lipsync":{"type":"boolean","title":"Lipsync","default":false},"subtitles":{"type":"boolean","title":"Subtitles","default":true}},"type":"object","required":["topic","duration_seconds","bg_value"],"title":"ManoleGenerateRequest"},"MassContentRequest":{"properties":{"strategy":{"type":"string","title":"Strategy","default":"aggressive_growth"},"content_volume":{"type":"integer","title":"Content Volume","default":50},"platforms":{"items":{"type":"string"},"type":"array","title":"Platforms","default":["instagram","tiktok","facebook","linkedin"]},"languages":{"items":{"type":"string"},"type":"array","title":"Languages","default":["romanian","english"]},"duration_days":{"type":"integer","title":"Duration Days","default":30}},"type":"object","title":"MassContentRequest"},"ProfessionalVideoRequest":{"properties":{"text":{"type":"string","title":"Text","default":"AutoPro Daune - Experții tăi în daune auto. Rezolvăm rapid și eficient!"},"duration":{"type":"integer","title":"Duration","default":15},"resolution":{"type":"string","title":"Resolution","default":"1080p"},"aspect_ratio":{"type":"string","title":"Aspect Ratio","default":"portrait"},"avatar_style":{"type":"string","title":"Avatar Style","default":"professional"},"background_type":{"type":"string","title":"Background Type","default":"office"},"voice_language":{"type":"string","title":"Voice Language","default":"ro"},"voice_gender":{"type":"string","title":"Voice Gender","default":"female"},"enable_subtitles":{"type":"boolean","title":"Enable Subtitles","default":true},"enable_lip_sync":{"type":"boolean","title":"Enable Lip Sync","default":true},"background_color":{"type":"string","title":"Background Color","default":"#1a73e8"},"text_color":{"type":"string","title":"Text Color","default":"#ffffff"}},"type":"object","title":"ProfessionalVideoRequest"},"ProfessionalVideoResponse":{"properties":{"success":{"type":"boolean","title":"Success"},"message":{"type":"string","title":"Message"},"video_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Video Path"},"thumbnail_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Thumbnail Path"},"file_size":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"File Size"},"duration":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Duration"},"specs":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Specs"}},"type":"object","required":["success","message"],"title":"ProfessionalVideoResponse"},"ROIAnalysisResponse":{"properties":{"period":{"type":"string","title":"Period"},"start_date":{"anyOf":[{"type":"string","format":"date"},{"type":"null"}],"title":"Start Date"},"end_date":{"anyOf":[{"type":"string","format":"date"},{"type":"null"}],"title":"End Date"},"total_costs":{"type":"string","title":"Total Costs"},"total_revenue":{"type":"string","title":"Total Revenue"},"net_profit":{"type":"string","title":"Net Profit"},"roi_percentage":{"type":"string","title":"Roi Percentage"},"cost_breakdown":{"additionalProperties":{"type":"string"},"type":"object","title":"Cost Breakdown"},"revenue_breakdown":{"additionalProperties":{"type":"string"},"type":"object","title":"Revenue Breakdown"},"cost_change_percentage":{"type":"string","title":"Cost Change Percentage"},"revenue_change_percentage":{"type":"string","title":"Revenue Change Percentage"},"profit_change_percentage":{"type":"string","title":"Profit Change Percentage"},"roi_change_percentage":{"type":"string","title":"Roi Change Percentage"},"recommendations":{"items":{"type":"string"},"type":"array","title":"Recommendations"}},"type":"object","required":["period","start_date","end_date","total_costs","total_revenue","net_profit","roi_percentage","cost_breakdown","revenue_breakdown","cost_change_percentage","revenue_change_percentage","profit_change_percentage","roi_change_percentage","recommendations"],"title":"ROIAnalysisResponse","description":"Schema pentru răspunsul cu analiza ROI."},"ReferralRequest":{"properties":{"referrer_id":{"type":"string","title":"Referrer Id"},"referee_name":{"type":"string","title":"Referee Name"},"referee_email":{"type":"string","title":"Referee Email"},"referee_phone":{"type":"string","title":"Referee Phone"},"damage_estimate":{"type":"number","title":"Damage Estimate"},"referral_source":{"type":"string","title":"Referral Source"},"campaign_type":{"type":"string","title":"Campaign Type","default":"friend_reward"}},"type":"object","required":["referrer_id","referee_name","referee_email","referee_phone","damage_estimate","referral_source"],"title":"ReferralRequest"},"RetryRequest":{"properties":{"job_id":{"type":"string","title":"Job Id"}},"type":"object","required":["job_id"],"title":"RetryRequest"},"ScheduleUpdateRequest":{"properties":{"schedule":{"items":{"type":"string"},"type":"array","title":"Schedule"},"daily_target":{"type":"integer","title":"Daily Target","default":3}},"type":"object","required":["schedule"],"title":"ScheduleUpdateRequest"},"SimpleVideoRequest":{"properties":{"text":{"type":"string","title":"Text","default":"AutoPro Daune - Rezolvă daunele rapid și simplu!"},"duration":{"type":"integer","title":"Duration","default":10},"width":{"type":"integer","title":"Width","default":720},"height":{"type":"integer","title":"Height","default":480},"background_color":{"type":"string","title":"Background Color","default":"#1a73e8"},"text_color":{"type":"string","title":"Text Color","default":"#ffffff"}},"type":"object","title":"SimpleVideoRequest"},"TrackEventRequest":{"properties":{"event_type":{"type":"string","title":"Event Type"},"source":{"type":"string","title":"Source"},"user_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"User Id"},"lead_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Lead Id"},"metadata":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Metadata"}},"type":"object","required":["event_type","source"],"title":"TrackEventRequest"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"},"VideoGenerateRequest":{"properties":{"template":{"type":"string","title":"Template"},"text":{"type":"string","title":"Text"},"duration":{"type":"integer","title":"Duration","default":30},"resolution":{"type":"string","enum":["720p","1080p","4k"],"title":"Resolution","default":"1080p"}},"type":"object","required":["template","text"],"title":"VideoGenerateRequest"},"VideoGenerationRequest":{"properties":{"template_type":{"type":"string","title":"Template Type","description":"Type: educational, testimonial, promotional"},"target_platforms":{"items":{"type":"string"},"type":"array","title":"Target Platforms","default":["tiktok","facebook","instagram"]},"scheduled_for":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Scheduled For"}},"type":"object","required":["template_type"],"title":"VideoGenerationRequest"},"VideoResponse":{"properties":{"success":{"type":"boolean","title":"Success"},"message":{"type":"string","title":"Message"},"video_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Video Path"},"file_size":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"File Size"},"duration":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Duration"}},"type":"object","required":["success","message"],"title":"VideoResponse"},"WorkingLeadCreate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"phone":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Phone"},"phone_number":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Phone Number"},"email":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Email"},"source":{"type":"string","title":"Source","default":"direct"},"notes":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Notes"}},"type":"object","title":"WorkingLeadCreate"}},"securitySchemes":{"HTTPBearer":{"type":"http","scheme":"bearer"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AutoPro Daune API",
+    "description": "Complete lead generation and automation system for AutoPro Daune",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health Check",
+        "description": "Basic health check endpoint.\n\nReturns:\n    Dictionary with health status and timestamp",
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Health Check Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test/mock-data": {
+      "get": {
+        "summary": "Test Mock Data",
+        "description": "Test endpoint with mock data - no database dependency",
+        "operationId": "test_mock_data_api_test_mock_data_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/working-leads/create": {
+      "post": {
+        "summary": "Create Working Lead",
+        "description": "Working lead creation endpoint that simulates real database operations",
+        "operationId": "create_working_lead_api_working_leads_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkingLeadCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "description": "Endpoint that serves Prometheus metrics.",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/": {
+      "get": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Get Leads",
+        "description": "Ob\u021bine lista de lead-uri cu filtrare \u0219i paginare.",
+        "operationId": "get_leads_api_leads__get",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Num\u0103rul paginii",
+              "default": 1,
+              "title": "Page"
+            },
+            "description": "Num\u0103rul paginii"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Num\u0103rul de lead-uri per pagin\u0103",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul de lead-uri per pagin\u0103"
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filtrare dup\u0103 surs\u0103",
+              "title": "Source"
+            },
+            "description": "Filtrare dup\u0103 surs\u0103"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filtrare dup\u0103 status",
+              "title": "Status"
+            },
+            "description": "Filtrare dup\u0103 status"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "C\u0103utare \u00een nume, email sau telefon",
+              "title": "Search"
+            },
+            "description": "C\u0103utare \u00een nume, email sau telefon"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Leads Api Leads  Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Create Lead",
+        "description": "Creeaz\u0103 un nou lead \u00een sistem.",
+        "operationId": "create_lead_api_leads__post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LeadCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Lead Api Leads  Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/{lead_id}": {
+      "get": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Get Lead",
+        "description": "Ob\u021bine un lead specific din Supabase.\n\nArgs:\n    lead_id: ID-ul lead-ului\n    \nReturns:\n    Dic\u021bionar cu datele lead-ului",
+        "operationId": "get_lead_api_leads__lead_id__get",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Lead Api Leads  Lead Id  Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Update Lead",
+        "description": "Actualizeaz\u0103 un lead existent \u00een Supabase.\n\nArgs:\n    lead_id: ID-ul lead-ului\n    update_data: Datele de actualizat\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "update_lead_api_leads__lead_id__put",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Update Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Lead Api Leads  Lead Id  Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Delete Lead",
+        "description": "\u0218terge un lead din Supabase.\n\nArgs:\n    lead_id: ID-ul lead-ului\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "delete_lead_api_leads__lead_id__delete",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Lead Api Leads  Lead Id  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/{lead_id}/score": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Score Lead",
+        "description": "Calculate and update lead score.\n\nArgs:\n    lead_id: ID of the lead to score\n    \nReturns:\n    Lead scoring results with priority and recommendation",
+        "operationId": "score_lead_api_leads__lead_id__score_post",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Score Lead Api Leads  Lead Id  Score Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/batch-score": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Batch Score Leads",
+        "description": "Batch score multiple leads and update priorities.\n\nArgs:\n    status: Optional filter by status\n    limit: Max number of leads to score\n    \nReturns:\n    Batch scoring results",
+        "operationId": "batch_score_leads_api_leads_batch_score_post",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Score leads with specific status",
+              "title": "Status"
+            },
+            "description": "Score leads with specific status"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Max leads to score",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Max leads to score"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Batch Score Leads Api Leads Batch Score Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/{lead_id}/activity": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Create Lead Activity",
+        "description": "Create a new activity/note for a lead.\n\nArgs:\n    lead_id: Lead UUID\n    activity: Activity data\n    \nReturns:\n    Created activity",
+        "operationId": "create_lead_activity_api_leads__lead_id__activity_post",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LeadActivityCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Lead Activity Api Leads  Lead Id  Activity Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/bulk-update": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Bulk Update Leads",
+        "description": "Bulk update multiple leads.\n\nArgs:\n    lead_ids: List of lead UUIDs\n    updates: Fields to update (status, priority, assigned_to, etc.)\n    \nReturns:\n    Update results",
+        "operationId": "bulk_update_leads_api_leads_bulk_update_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_bulk_update_leads_api_leads_bulk_update_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Bulk Update Leads Api Leads Bulk Update Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/export": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Export Leads",
+        "description": "Export leads to CSV or JSON.\n\nArgs:\n    status: Filter by status\n    source: Filter by source\n    format: Export format (csv or json)\n    \nReturns:\n    Export data",
+        "operationId": "export_leads_api_leads_export_post",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^(csv|json)$",
+              "default": "csv",
+              "title": "Format"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Export Leads Api Leads Export Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/{lead_id}/timeline": {
+      "get": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Get Lead Timeline",
+        "description": "Get activity timeline for a lead.\n\nArgs:\n    lead_id: Lead UUID\n    activity_type: Optional filter by type\n    limit: Max activities to return\n    \nReturns:\n    List of activities ordered by date (newest first)",
+        "operationId": "get_lead_timeline_api_leads__lead_id__timeline_get",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Lead Id"
+            }
+          },
+          {
+            "name": "activity_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by activity type",
+              "title": "Activity Type"
+            },
+            "description": "Filter by activity type"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "description": "Max activities to return",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Max activities to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Lead Timeline Api Leads  Lead Id  Timeline Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/upload-attachment": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Upload Lead Attachment",
+        "description": "Upload file attachment for a lead.\n\nArgs:\n    file: File to upload\n    lead_id: Lead ID\n    \nReturns:\n    File URL and metadata",
+        "operationId": "upload_lead_attachment_api_leads_upload_attachment_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_lead_attachment_api_leads_upload_attachment_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Upload Lead Attachment Api Leads Upload Attachment Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/{lead_id}/send-email": {
+      "post": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Send Email To Lead",
+        "description": "Send email to a lead.\n\nArgs:\n    lead_id: Lead ID\n    subject: Email subject\n    message: Email message\n    template: Optional template name\n    \nReturns:\n    Success message",
+        "operationId": "send_email_to_lead_api_leads__lead_id__send_email_post",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_email_to_lead_api_leads__lead_id__send_email_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Send Email To Lead Api Leads  Lead Id  Send Email Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leads/email-templates": {
+      "get": {
+        "tags": [
+          "leads"
+        ],
+        "summary": "Get Email Templates",
+        "description": "Get available email templates.\n\nReturns:\n    List of email templates",
+        "operationId": "get_email_templates_api_leads_email_templates_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Email Templates Api Leads Email Templates Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/referrals/": {
+      "get": {
+        "tags": [
+          "referrals"
+        ],
+        "summary": "Get Referrals",
+        "description": "Ob\u021bine lista de referrals din Supabase.\n\nArgs:\n    limit: Num\u0103rul maxim de referrals\n    offset: Offset pentru paginare\n    status: Status-ul referrals (op\u021bional)\n    \nReturns:\n    Dic\u021bionar cu lista de referrals",
+        "operationId": "get_referrals_api_referrals__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul maxim de referrals de returnat",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul maxim de referrals de returnat"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Offset pentru paginare",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Offset pentru paginare"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Status-ul referrals (pending, completed, cancelled)",
+              "title": "Status"
+            },
+            "description": "Status-ul referrals (pending, completed, cancelled)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Referrals Api Referrals  Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "referrals"
+        ],
+        "summary": "Create Referral",
+        "description": "Creeaz\u0103 un referral nou \u00een Supabase.\n\nArgs:\n    referral_data: Datele referral-ului\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "create_referral_api_referrals__post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Referral Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Referral Api Referrals  Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/referrals/stats": {
+      "get": {
+        "tags": [
+          "referrals"
+        ],
+        "summary": "Get Referral Stats",
+        "description": "Ob\u021bine statistici despre referrals din Supabase.\n\nReturns:\n    Dic\u021bionar cu statisticile",
+        "operationId": "get_referral_stats_api_referrals_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Referral Stats Api Referrals Stats Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/referrals/{referral_id}/complete": {
+      "put": {
+        "tags": [
+          "referrals"
+        ],
+        "summary": "Complete Referral",
+        "description": "Marcheaz\u0103 un referral ca fiind completat \u00een Supabase.\n\nArgs:\n    referral_id: ID-ul referral-ului\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "complete_referral_api_referrals__referral_id__complete_put",
+        "parameters": [
+          {
+            "name": "referral_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Referral Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Complete Referral Api Referrals  Referral Id  Complete Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/track-cost": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Track Api Cost",
+        "description": "\u00cenregistreaz\u0103 un cost API nou \u00een Supabase.\n\nArgs:\n    cost_data: Datele costului de \u00eenregistrat\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "track_api_cost_api_financial_track_cost_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Cost Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Track Api Cost Api Financial Track Cost Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/track-cost/{cost_id}": {
+      "put": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Update Api Cost",
+        "description": "Actualizeaz\u0103 un cost API existent \u00een Supabase.\n\nArgs:\n    cost_id: ID-ul costului de actualizat\n    cost_data: Datele noi pentru cost\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "update_api_cost_api_financial_track_cost__cost_id__put",
+        "parameters": [
+          {
+            "name": "cost_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "ID-ul costului",
+              "title": "Cost Id"
+            },
+            "description": "ID-ul costului"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Cost Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Api Cost Api Financial Track Cost  Cost Id  Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Delete Api Cost",
+        "description": "\u0218terge un cost API din Supabase.\n\nArgs:\n    cost_id: ID-ul costului de \u0219ters\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "delete_api_cost_api_financial_track_cost__cost_id__delete",
+        "parameters": [
+          {
+            "name": "cost_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "ID-ul costului",
+              "title": "Cost Id"
+            },
+            "description": "ID-ul costului"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Api Cost Api Financial Track Cost  Cost Id  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/track-revenue": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Track Revenue",
+        "description": "\u00cenregistreaz\u0103 un venit nou \u00een Supabase.\n\nArgs:\n    revenue_data: Datele venitului de \u00eenregistrat\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "track_revenue_api_financial_track_revenue_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Revenue Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Track Revenue Api Financial Track Revenue Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/track-revenue/{revenue_id}": {
+      "put": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Update Revenue",
+        "description": "Actualizeaz\u0103 un venit existent \u00een Supabase.\n\nArgs:\n    revenue_id: ID-ul venitului de actualizat\n    revenue_data: Datele noi pentru venit\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "update_revenue_api_financial_track_revenue__revenue_id__put",
+        "parameters": [
+          {
+            "name": "revenue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "ID-ul venitului",
+              "title": "Revenue Id"
+            },
+            "description": "ID-ul venitului"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Revenue Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Revenue Api Financial Track Revenue  Revenue Id  Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Delete Revenue",
+        "description": "\u0218terge un venit din Supabase.\n\nArgs:\n    revenue_id: ID-ul venitului de \u0219ters\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "delete_revenue_api_financial_track_revenue__revenue_id__delete",
+        "parameters": [
+          {
+            "name": "revenue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "ID-ul venitului",
+              "title": "Revenue Id"
+            },
+            "description": "ID-ul venitului"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Revenue Api Financial Track Revenue  Revenue Id  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/calculate-daily-metrics/{target_date}": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Calculate Daily Metrics",
+        "description": "Calculeaz\u0103 metricile financiare pentru o dat\u0103 specificat\u0103.\n\nArgs:\n    target_date: Data pentru care se calculeaz\u0103 metricile\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu metricile calculate",
+        "operationId": "calculate_daily_metrics_api_financial_calculate_daily_metrics__target_date__post",
+        "parameters": [
+          {
+            "name": "target_date",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Data pentru care se calculeaz\u0103 metricile",
+              "title": "Target Date"
+            },
+            "description": "Data pentru care se calculeaz\u0103 metricile"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/roi/{period}": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Roi Analysis",
+        "description": "Ob\u021bine analiza ROI pentru o perioad\u0103 specificat\u0103 sau interval custom.\n\nArgs:\n    period: Perioada preset pentru analiz\u0103\n    date_from: Data start custom (op\u021bional, override period)\n    date_to: Data end custom (op\u021bional, override period)\n    \nReturns:\n    Obiect ROIData cu rezultatul",
+        "operationId": "get_roi_analysis_api_financial_roi__period__get",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Perioada pentru analiza ROI (today, 7d, 30d, mtd, ytd)",
+              "title": "Period"
+            },
+            "description": "Perioada pentru analiza ROI (today, 7d, 30d, mtd, ytd)"
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Data start custom (YYYY-MM-DD)",
+              "title": "Date From"
+            },
+            "description": "Data start custom (YYYY-MM-DD)"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Data end custom (YYYY-MM-DD)",
+              "title": "Date To"
+            },
+            "description": "Data end custom (YYYY-MM-DD)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ROIAnalysisResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/payments": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Payments",
+        "description": "Get payment tracking data.",
+        "operationId": "get_payments_api_financial_payments_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Payment status filter",
+              "title": "Status"
+            },
+            "description": "Payment status filter"
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Start date (YYYY-MM-DD)",
+              "title": "Date From"
+            },
+            "description": "Start date (YYYY-MM-DD)"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "End date (YYYY-MM-DD)",
+              "title": "Date To"
+            },
+            "description": "End date (YYYY-MM-DD)"
+          },
+          {
+            "name": "client_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Client ID filter",
+              "title": "Client Id"
+            },
+            "description": "Client ID filter"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Number of payments to return",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Number of payments to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Payments Api Financial Payments Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Create Payment",
+        "description": "Create a new payment record.",
+        "operationId": "create_payment_api_financial_payments_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_payment_api_financial_payments_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Payment Api Financial Payments Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/payments/overview": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Payment Overview",
+        "description": "Get payment overview statistics.",
+        "operationId": "get_payment_overview_api_financial_payments_overview_get",
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Time period (7d, 30d, 90d, 1y)",
+              "default": "30d",
+              "title": "Period"
+            },
+            "description": "Time period (7d, 30d, 90d, 1y)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Payment Overview Api Financial Payments Overview Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/invoices": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Invoices",
+        "description": "Get invoice data.",
+        "operationId": "get_invoices_api_financial_invoices_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Invoice status filter",
+              "title": "Status"
+            },
+            "description": "Invoice status filter"
+          },
+          {
+            "name": "client_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Client ID filter",
+              "title": "Client Id"
+            },
+            "description": "Client ID filter"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Number of invoices to return",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Number of invoices to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Invoices Api Financial Invoices Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Create Invoice",
+        "description": "Create a new invoice.",
+        "operationId": "create_invoice_api_financial_invoices_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_invoice_api_financial_invoices_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Invoice Api Financial Invoices Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/budget-plans": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Budget Plans",
+        "description": "Get budget plans.",
+        "operationId": "get_budget_plans_api_financial_budget_plans_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Budget Plans Api Financial Budget Plans Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Create Budget Plan",
+        "description": "Create a new budget plan.",
+        "operationId": "create_budget_plan_api_financial_budget_plans_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_budget_plan_api_financial_budget_plans_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Create Budget Plan Api Financial Budget Plans Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/profit-loss": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Profit Loss",
+        "description": "Ob\u021bine analiza profit/pierdere pentru o perioad\u0103 specificat\u0103 din Supabase.\n\nArgs:\n    start_date: Data de \u00eenceput\n    end_date: Data de sf\u00e2r\u0219it\n    \nReturns:\n    Dic\u021bionar cu datele profit/pierdere",
+        "operationId": "get_profit_loss_api_financial_profit_loss_get",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Data de \u00eenceput",
+              "title": "Start Date"
+            },
+            "description": "Data de \u00eenceput"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Data de sf\u00e2r\u0219it",
+              "title": "End Date"
+            },
+            "description": "Data de sf\u00e2r\u0219it"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Analiz\u0103 profit/pierdere",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfitLossResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/dashboard": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Financial Dashboard",
+        "description": "Ob\u021bine datele pentru dashboard-ul financiar din Supabase.\n\nArgs:\n    date_from: Data start pentru filtrare (op\u021bional)\n    date_to: Data end pentru filtrare (op\u021bional)\n    period: Perioada preset (default: 7d)\n\nReturns:\n    Dic\u021bionar cu datele dashboard-ului",
+        "operationId": "get_financial_dashboard_api_financial_dashboard_get",
+        "parameters": [
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Data start (YYYY-MM-DD)",
+              "title": "Date From"
+            },
+            "description": "Data start (YYYY-MM-DD)"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Data end (YYYY-MM-DD)",
+              "title": "Date To"
+            },
+            "description": "Data end (YYYY-MM-DD)"
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Perioada (today, 7d, 30d, mtd, ytd)",
+              "default": "7d",
+              "title": "Period"
+            },
+            "description": "Perioada (today, 7d, 30d, mtd, ytd)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/campaigns": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Create Campaign",
+        "description": "Creeaz\u0103 o campanie nou\u0103.\n\nArgs:\n    campaign_data: Datele campaniei\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "create_campaign_api_financial_campaigns_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CampaignMetricsCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Campaign Api Financial Campaigns Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Campaigns",
+        "description": "Ob\u021bine lista de campanii.\n\nArgs:\n    limit: Num\u0103rul maxim de campanii\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Lista de campanii",
+        "operationId": "get_campaigns_api_financial_campaigns_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul maxim de campanii de returnat",
+              "default": 10,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul maxim de campanii de returnat"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CampaignMetricsResponse"
+                  },
+                  "title": "Response Get Campaigns Api Financial Campaigns Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/campaigns/{campaign_id}": {
+      "put": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Update Campaign",
+        "description": "Actualizeaz\u0103 o campanie existent\u0103.\n\nArgs:\n    campaign_id: ID-ul campaniei\n    update_data: Datele de actualizat\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "update_campaign_api_financial_campaigns__campaign_id__put",
+        "parameters": [
+          {
+            "name": "campaign_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "ID-ul campaniei",
+              "title": "Campaign Id"
+            },
+            "description": "ID-ul campaniei"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Update Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Campaign Api Financial Campaigns  Campaign Id  Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/credit-balance/{provider}": {
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Credit Balance",
+        "description": "Ob\u021bine balan\u021ba de credite pentru un provider.\n\nArgs:\n    provider: Numele providerului\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Obiect CreditBalance cu balan\u021ba",
+        "operationId": "get_credit_balance_api_financial_credit_balance__provider__get",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Providerul pentru care se ob\u021bine balan\u021ba",
+              "title": "Provider"
+            },
+            "description": "Providerul pentru care se ob\u021bine balan\u021ba"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreditBalanceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Update Credit Balance",
+        "description": "Actualizeaz\u0103 balan\u021ba de credite pentru un provider.\n\nArgs:\n    provider: Numele providerului\n    amount: Suma de actualizat\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "update_credit_balance_api_financial_credit_balance__provider__put",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Providerul pentru care se actualizeaz\u0103 balan\u021ba",
+              "title": "Provider"
+            },
+            "description": "Providerul pentru care se actualizeaz\u0103 balan\u021ba"
+          },
+          {
+            "name": "amount",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Suma de actualizat",
+              "title": "Amount"
+            },
+            "description": "Suma de actualizat"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Credit Balance Api Financial Credit Balance  Provider  Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/budget-alerts": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Create Budget Alert",
+        "description": "Creeaz\u0103 o alert\u0103 de buget nou\u0103.\n\nArgs:\n    alert_data: Datele alertei\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "create_budget_alert_api_financial_budget_alerts_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BudgetAlertCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Budget Alert Api Financial Budget Alerts Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Get Budget Alerts",
+        "description": "Ob\u021bine lista de alerte de buget.\n\nArgs:\n    limit: Num\u0103rul maxim de alerte\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Lista de alerte de buget",
+        "operationId": "get_budget_alerts_api_financial_budget_alerts_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul maxim de alerte de returnat",
+              "default": 10,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul maxim de alerte de returnat"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BudgetAlertResponse"
+                  },
+                  "title": "Response Get Budget Alerts Api Financial Budget Alerts Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/calculate-cost/pika": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Calculate Pika Cost",
+        "description": "Calculeaz\u0103 costul pentru generarea video cu Pika.\n\nArgs:\n    duration_seconds: Durata \u00een secunde\n    resolution: Rezolu\u021bia (720p, 1080p, 4K)\n    quality: Calitatea (low, medium, high)\n    \nReturns:\n    Dic\u021bionar cu costul calculat",
+        "operationId": "calculate_pika_cost_api_financial_calculate_cost_pika_post",
+        "parameters": [
+          {
+            "name": "duration_seconds",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Durata video-ului \u00een secunde",
+              "title": "Duration Seconds"
+            },
+            "description": "Durata video-ului \u00een secunde"
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Rezolu\u021bia video-ului",
+              "default": "720p",
+              "title": "Resolution"
+            },
+            "description": "Rezolu\u021bia video-ului"
+          },
+          {
+            "name": "quality",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Calitatea video-ului",
+              "default": "high",
+              "title": "Quality"
+            },
+            "description": "Calitatea video-ului"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Calculate Pika Cost Api Financial Calculate Cost Pika Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/calculate-cost/heygen": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Calculate Heygen Cost",
+        "description": "Calculeaz\u0103 costul pentru generarea video cu HeyGen.\n\nArgs:\n    duration_seconds: Durata \u00een secunde\n    avatar_type: Tipul avatarului\n    voice_type: Tipul vocii\n    \nReturns:\n    Dic\u021bionar cu costul calculat",
+        "operationId": "calculate_heygen_cost_api_financial_calculate_cost_heygen_post",
+        "parameters": [
+          {
+            "name": "duration_seconds",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Durata video-ului \u00een secunde",
+              "title": "Duration Seconds"
+            },
+            "description": "Durata video-ului \u00een secunde"
+          },
+          {
+            "name": "avatar_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tipul avatarului",
+              "default": "default",
+              "title": "Avatar Type"
+            },
+            "description": "Tipul avatarului"
+          },
+          {
+            "name": "voice_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tipul vocii",
+              "default": "standard",
+              "title": "Voice Type"
+            },
+            "description": "Tipul vocii"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Calculate Heygen Cost Api Financial Calculate Cost Heygen Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/calculate-cost/social-media": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Calculate Social Media Cost",
+        "description": "Calculeaz\u0103 costul pentru postarea pe social media.\n\nArgs:\n    platform: Platforma de postare\n    content_type: Tipul con\u021binutului\n    file_size_mb: M\u0103rimea fi\u0219ierului\n    \nReturns:\n    Dic\u021bionar cu costul calculat",
+        "operationId": "calculate_social_media_cost_api_financial_calculate_cost_social_media_post",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Platforma (TikTok, Instagram, YouTube)",
+              "title": "Platform"
+            },
+            "description": "Platforma (TikTok, Instagram, YouTube)"
+          },
+          {
+            "name": "content_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tipul con\u021binutului",
+              "default": "video",
+              "title": "Content Type"
+            },
+            "description": "Tipul con\u021binutului"
+          },
+          {
+            "name": "file_size_mb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "M\u0103rimea fi\u0219ierului \u00een MB",
+              "title": "File Size Mb"
+            },
+            "description": "M\u0103rimea fi\u0219ierului \u00een MB"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Calculate Social Media Cost Api Financial Calculate Cost Social Media Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/estimate-monthly-costs": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Estimate Monthly Costs",
+        "description": "Estimeaz\u0103 costurile lunare bazate pe un plan de utilizare.\n\nArgs:\n    usage_plan: Planul de utilizare\n    \nReturns:\n    Dic\u021bionar cu estimarea costurilor",
+        "operationId": "estimate_monthly_costs_api_financial_estimate_monthly_costs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Usage Plan"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Estimate Monthly Costs Api Financial Estimate Monthly Costs Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/estimate-budget-requirements": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Estimate Budget Requirements",
+        "description": "Estimeaz\u0103 cerin\u021bele de buget bazate pe ROI \u021bint\u0103.\n\nArgs:\n    target_roi: ROI-ul \u021bint\u0103\n    expected_revenue: Veniturile a\u0219teptate\n    time_period_days: Perioada \u00een zile\n    \nReturns:\n    Dic\u021bionar cu estimarea cerin\u021belor",
+        "operationId": "estimate_budget_requirements_api_financial_estimate_budget_requirements_post",
+        "parameters": [
+          {
+            "name": "target_roi",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "ROI-ul \u021bint\u0103 \u00een procente",
+              "title": "Target Roi"
+            },
+            "description": "ROI-ul \u021bint\u0103 \u00een procente"
+          },
+          {
+            "name": "expected_revenue",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Veniturile a\u0219teptate",
+              "title": "Expected Revenue"
+            },
+            "description": "Veniturile a\u0219teptate"
+          },
+          {
+            "name": "time_period_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Perioada \u00een zile",
+              "default": 30,
+              "title": "Time Period Days"
+            },
+            "description": "Perioada \u00een zile"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Estimate Budget Requirements Api Financial Estimate Budget Requirements Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/optimize-costs": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Optimize Costs",
+        "description": "Sugereaz\u0103 optimiz\u0103ri pentru reducerea costurilor.\n\nArgs:\n    current_usage: Utilizarea curent\u0103\n    budget_limit: Limita de buget\n    \nReturns:\n    Dic\u021bionar cu sugestiile de optimizare",
+        "operationId": "optimize_costs_api_financial_optimize_costs_post",
+        "parameters": [
+          {
+            "name": "budget_limit",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Limita de buget",
+              "title": "Budget Limit"
+            },
+            "description": "Limita de buget"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Current Usage"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Optimize Costs Api Financial Optimize Costs Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/optimize-budget-allocation": {
+      "post": {
+        "tags": [
+          "financial"
+        ],
+        "summary": "Optimize Budget Allocation",
+        "description": "Optimizeaz\u0103 alocarea bugetului bazat\u0103 pe performan\u021ba campaniilor.\n\nArgs:\n    total_budget: Bugetul total\n    campaign_performance: Performan\u021ba campaniilor\n    \nReturns:\n    Dic\u021bionar cu alocarea optimizat\u0103",
+        "operationId": "optimize_budget_allocation_api_financial_optimize_budget_allocation_post",
+        "parameters": [
+          {
+            "name": "total_budget",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Bugetul total",
+              "title": "Total Budget"
+            },
+            "description": "Bugetul total"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "description": "Performan\u021ba campaniilor",
+                "default": [],
+                "title": "Campaign Performance"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Optimize Budget Allocation Api Financial Optimize Budget Allocation Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/summary": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Get Social Summary",
+        "description": "Ob\u021bine sumarul activit\u0103\u021bii pe social media din Supabase.\n\nReturns:\n    Dic\u021bionar cu sumarul social media",
+        "operationId": "get_social_summary_api_social_summary_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Social Summary Api Social Summary Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/social/post-now": {
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Post Now",
+        "description": "Posteaz\u0103 imediat pe o platform\u0103 social media.\n\nArgs:\n    platform: Platforma pentru postare\n    background_tasks: Background tasks pentru procesare asincron\u0103\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "post_now_api_social_post_now_post",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Platforma pentru postare (tiktok, instagram, youtube)",
+              "title": "Platform"
+            },
+            "description": "Platforma pentru postare (tiktok, instagram, youtube)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Post Now Api Social Post Now Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/posts": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Get Recent Posts",
+        "description": "Ob\u021bine post\u0103rile recente de pe social media din Supabase.\n\nArgs:\n    platform: Platforma specific\u0103 (op\u021bional)\n    limit: Num\u0103rul maxim de post\u0103ri\n    \nReturns:\n    Dic\u021bionar cu post\u0103rile recente",
+        "operationId": "get_recent_posts_api_social_posts_get",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Platforma specific\u0103 (op\u021bional)",
+              "title": "Platform"
+            },
+            "description": "Platforma specific\u0103 (op\u021bional)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul maxim de post\u0103ri",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul maxim de post\u0103ri"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Recent Posts Api Social Posts Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Create Social Post",
+        "description": "Creeaz\u0103 o postare social media nou\u0103 \u00een Supabase.\n\nArgs:\n    post_data: Datele post\u0103rii\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "create_social_post_api_social_posts_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Post Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Social Post Api Social Posts Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/posts/{post_id}": {
+      "put": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Update Social Post",
+        "description": "Actualizeaz\u0103 o postare social media existent\u0103 \u00een Supabase.\n\nArgs:\n    post_id: ID-ul post\u0103rii\n    post_data: Datele noi pentru postare\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "update_social_post_api_social_posts__post_id__put",
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Post Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Post Data"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Update Social Post Api Social Posts  Post Id  Put"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Delete Social Post",
+        "description": "\u0218terge o postare social media din Supabase.\n\nArgs:\n    post_id: ID-ul post\u0103rii\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "delete_social_post_api_social_posts__post_id__delete",
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Post Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Social Post Api Social Posts  Post Id  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/analytics": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Get Social Analytics",
+        "description": "Ob\u021bine analitica pentru social media.\n\nArgs:\n    platform: Platforma specific\u0103 (op\u021bional)\n    days: Num\u0103rul de zile pentru analiz\u0103\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu analitica",
+        "operationId": "get_social_analytics_api_social_analytics_get",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Platforma specific\u0103 (op\u021bional)",
+              "title": "Platform"
+            },
+            "description": "Platforma specific\u0103 (op\u021bional)"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul de zile pentru analiz\u0103",
+              "default": 7,
+              "title": "Days"
+            },
+            "description": "Num\u0103rul de zile pentru analiz\u0103"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Social Analytics Api Social Analytics Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/bots/start": {
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Start Social Bots",
+        "description": "Porne\u0219te bot-urile pentru social media.\n\nArgs:\n    platforms: Lista de platforme (op\u021bional, toate dac\u0103 nu este specificat)\n    background_tasks: Background tasks\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "start_social_bots_api_social_bots_start_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "title": "Platforms"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Start Social Bots Api Social Bots Start Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/bots/stop": {
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Stop Social Bots",
+        "description": "Opre\u0219te bot-urile pentru social media.\n\nArgs:\n    platforms: Lista de platforme (op\u021bional, toate dac\u0103 nu este specificat)\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "stop_social_bots_api_social_bots_stop_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "title": "Platforms"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Stop Social Bots Api Social Bots Stop Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/followers": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Get All Followers",
+        "description": "Get follower/subscriber counts from all social media platforms.\n\nReturns:\n    Dictionary with metrics from TikTok, Instagram, and YouTube",
+        "operationId": "get_all_followers_api_social_followers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get All Followers Api Social Followers Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/social/followers/{platform}": {
+      "get": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Get Platform Followers",
+        "description": "Get follower count for a specific platform.\n\nArgs:\n    platform: Platform name (tiktok, instagram, youtube)\n    \nReturns:\n    Dictionary with platform-specific metrics",
+        "operationId": "get_platform_followers_api_social_followers__platform__get",
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Platform"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Platform Followers Api Social Followers  Platform  Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/social/upload-video": {
+      "post": {
+        "tags": [
+          "social"
+        ],
+        "summary": "Upload Video For Posting",
+        "description": "Upload video and create social media post.\n\nSteps:\n1. Validate video file\n2. Upload to Supabase Storage\n3. Create post record in database\n4. Return success with media URL",
+        "operationId": "upload_video_for_posting_api_social_upload_video_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_video_for_posting_api_social_upload_video_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Upload Video For Posting Api Social Upload Video Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logs/": {
+      "get": {
+        "tags": [
+          "logs"
+        ],
+        "summary": "Get Logs",
+        "description": "Ob\u021bine log-urile aplica\u021biei din Supabase.\n\nArgs:\n    level: Nivelul de log\n    limit: Num\u0103rul maxim de log-uri\n    service: Serviciul specific (op\u021bional)\n    \nReturns:\n    Dic\u021bionar cu log-urile",
+        "operationId": "get_logs_api_logs__get",
+        "parameters": [
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Nivelul de log (debug, info, warning, error, critical)",
+              "default": "info",
+              "title": "Level"
+            },
+            "description": "Nivelul de log (debug, info, warning, error, critical)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul maxim de log-uri",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul maxim de log-uri"
+          },
+          {
+            "name": "service",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Serviciul specific (op\u021bional)",
+              "title": "Service"
+            },
+            "description": "Serviciul specific (op\u021bional)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Logs Api Logs  Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "logs"
+        ],
+        "summary": "Clear Logs",
+        "description": "\u0218terge log-urile vechi.\n\nArgs:\n    older_than_days: \u0218terge log-urile mai vechi de X zile\n    level: Nivelul specific (op\u021bional)\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "clear_logs_api_logs__delete",
+        "parameters": [
+          {
+            "name": "older_than_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "\u0218terge log-urile mai vechi de X zile",
+              "default": 30,
+              "title": "Older Than Days"
+            },
+            "description": "\u0218terge log-urile mai vechi de X zile"
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Nivelul specific (op\u021bional)",
+              "title": "Level"
+            },
+            "description": "Nivelul specific (op\u021bional)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Clear Logs Api Logs  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logs/stats": {
+      "get": {
+        "tags": [
+          "logs"
+        ],
+        "summary": "Get Log Stats",
+        "description": "Ob\u021bine statistici despre log-uri.\n\nArgs:\n    days: Num\u0103rul de zile pentru statistici\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu statisticile",
+        "operationId": "get_log_stats_api_logs_stats_get",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103rul de zile pentru statistici",
+              "default": 7,
+              "title": "Days"
+            },
+            "description": "Num\u0103rul de zile pentru statistici"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Log Stats Api Logs Stats Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logs/services": {
+      "get": {
+        "tags": [
+          "logs"
+        ],
+        "summary": "Get Log Services",
+        "description": "Ob\u021bine lista de servicii care genereaz\u0103 log-uri.\n\nArgs:\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Lista de servicii",
+        "operationId": "get_log_services_api_logs_services_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Get Log Services Api Logs Services Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/logs/test": {
+      "post": {
+        "tags": [
+          "logs"
+        ],
+        "summary": "Create Test Log",
+        "description": "Creeaz\u0103 un log de test.\n\nArgs:\n    level: Nivelul de log\n    message: Mesajul de log\n    service: Serviciul\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "create_test_log_api_logs_test_post",
+        "parameters": [
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Nivelul de log",
+              "default": "info",
+              "title": "Level"
+            },
+            "description": "Nivelul de log"
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Mesajul de log",
+              "default": "Test log entry",
+              "title": "Message"
+            },
+            "description": "Mesajul de log"
+          },
+          {
+            "name": "service",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Serviciul",
+              "default": "admin",
+              "title": "Service"
+            },
+            "description": "Serviciul"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Create Test Log Api Logs Test Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/detailed": {
+      "get": {
+        "summary": "Detailed Health Check",
+        "description": "Detailed health check with dependency status.\n\nReturns:\n    Dictionary with detailed health information",
+        "operationId": "detailed_health_check_health_detailed_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Detailed Health Check Health Detailed Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/": {
+      "get": {
+        "tags": [
+          "content"
+        ],
+        "summary": "List content items",
+        "operationId": "list_items_api_content__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "type": "array",
+                  "title": "Response List Items Api Content  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "content"
+        ],
+        "summary": "Create content item",
+        "operationId": "create_item_api_content__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContentBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Create Item Api Content  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{item_id}": {
+      "get": {
+        "tags": [
+          "content"
+        ],
+        "summary": "Get one content item",
+        "operationId": "get_item_api_content__item_id__get",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Item Api Content  Item Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{item_id}/validate": {
+      "post": {
+        "tags": [
+          "content"
+        ],
+        "summary": "Validate item",
+        "operationId": "validate_item_api_content__item_id__validate_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Validate Item Api Content  Item Id  Validate Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{item_id}/process-assets": {
+      "post": {
+        "tags": [
+          "content"
+        ],
+        "summary": "Process assets (thumbs/metadata)",
+        "operationId": "process_assets_api_content__item_id__process_assets_post",
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Process Assets Api Content  Item Id  Process Assets Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/automation/status": {
+      "get": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "Get Automation Status",
+        "description": "Ob\u021bine statusul sistemului de automatizare.\n\nReturns:\n    Dic\u021bionar cu statusul automatiz\u0103rii",
+        "operationId": "get_automation_status_api_automation_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Automation Status Api Automation Status Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/automation/schedule/configure": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "Configure Schedule",
+        "description": "Configureaz\u0103 programul de automatizare.",
+        "operationId": "configure_schedule_api_automation_schedule_configure_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutomationSchedule"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Configure Schedule Api Automation Schedule Configure Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/automation/video/generate-and-post": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "Generate And Post Video",
+        "description": "Genereaz\u0103 \u0219i posteaz\u0103 un video automat.",
+        "operationId": "generate_and_post_video_api_automation_video_generate_and_post_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VideoGenerationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Generate And Post Video Api Automation Video Generate And Post Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/automation/daily-cycle/trigger": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "Trigger Daily Cycle",
+        "description": "Declan\u0219eaz\u0103 ciclul zilnic de automatizare (3 videouri).",
+        "operationId": "trigger_daily_cycle_api_automation_daily_cycle_trigger_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Trigger Daily Cycle Api Automation Daily Cycle Trigger Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/automation/performance": {
+      "get": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "Get Automation Performance",
+        "description": "Ob\u021bine performan\u021ba sistemului de automatizare.",
+        "operationId": "get_automation_performance_api_automation_performance_get",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Number of days to analyze",
+              "default": 7,
+              "title": "Days"
+            },
+            "description": "Number of days to analyze"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Automation Performance Api Automation Performance Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/automation/whatsapp/optimize": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "summary": "Optimize Whatsapp Responses",
+        "description": "Optimizeaz\u0103 r\u0103spunsurile WhatsApp Bot.",
+        "operationId": "optimize_whatsapp_responses_api_automation_whatsapp_optimize_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Optimize Whatsapp Responses Api Automation Whatsapp Optimize Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/video/queue": {
+      "get": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Get Video Queue",
+        "description": "Ob\u021bine coada de procesare video din Supabase.\n\nArgs:\n    status: Status-ul job-urilor (op\u021bional)\n    limit: Num\u0103rul maxim de job-uri (1-200)\n    \nReturns:\n    Dic\u021bionar cu coada de video",
+        "operationId": "get_video_queue_api_video_queue_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/JobStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "queued|processing|completed|failed|cancelled",
+              "title": "Status"
+            },
+            "description": "queued|processing|completed|failed|cancelled"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "description": "Num\u0103rul maxim de job-uri",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Num\u0103rul maxim de job-uri"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Video Queue Api Video Queue Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/retry": {
+      "post": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Retry Video Job",
+        "description": "Re\u00eencearc\u0103 procesarea unui job video.\n\nArgs:\n    payload: Request payload with job_id\n    _auth: Authentication credentials\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "retry_video_job_api_video_retry_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Retry Video Job Api Video Retry Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/video/generate": {
+      "post": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Generate Video",
+        "description": "Genereaz\u0103 un video nou.\n\nArgs:\n    video_data: Datele pentru generarea video-ului\n    _auth: Authentication credentials\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "generate_video_api_video_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VideoGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Generate Video Api Video Generate Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/video/manole-generate": {
+      "post": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Generate Manole Video",
+        "description": "Genereaz\u0103 un video personalizat cu Manole ca prezentator.\n\nArgs:\n    manole_data: Datele pentru generarea video-ului Manole\n    background_tasks: Background tasks pentru procesare\n    _auth: Authentication credentials\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "generate_manole_video_api_video_manole_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManoleGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Generate Manole Video Api Video Manole Generate Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/video/stats": {
+      "get": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Get Video Stats",
+        "description": "Ob\u021bine statistici despre procesarea video-urilor.\n\nReturns:\n    Dic\u021bionar cu statisticile",
+        "operationId": "get_video_stats_api_video_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Video Stats Api Video Stats Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/video/queue/{job_id}": {
+      "delete": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Cancel Video Job",
+        "description": "Anuleaz\u0103 un job video.\n\nArgs:\n    job_id: ID-ul job-ului\n    _auth: Authentication credentials\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "cancel_video_job_api_video_queue__job_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Cancel Video Job Api Video Queue  Job Id  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/manole/generate": {
+      "post": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Generate Manole Video",
+        "description": "Generate video with Manole talking + accident footage.\n\nThis endpoint creates a professional video by:\n1. Animating Manole's photo with Ken Burns effect\n2. Generating voice using ElevenLabs (or Edge-TTS fallback)\n3. Overlaying accident footage if provided\n4. Adding WhatsApp CTA overlay\n\nReturns video URL and metadata.",
+        "operationId": "generate_manole_video_api_video_video_manole_generate_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_generate_manole_video_api_video_video_manole_generate_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/batch": {
+      "delete": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Batch Delete Videos",
+        "description": "Delete multiple videos in batch.\n\nArgs:\n    video_ids: List of video IDs to delete\n    \nReturns:\n    Success status and count of deleted videos",
+        "operationId": "batch_delete_videos_api_video_video_batch_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "title": "Video Ids"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Batch Delete Videos Api Video Video Batch Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/{video_id}": {
+      "delete": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Delete Video",
+        "description": "Delete a video from database and storage.\n\nArgs:\n    video_id: Video ID or job ID\n    \nReturns:\n    Deletion result",
+        "operationId": "delete_video_api_video_video__video_id__delete",
+        "parameters": [
+          {
+            "name": "video_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Video Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Video Api Video Video  Video Id  Delete"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/{video_id}/download": {
+      "get": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Download Video",
+        "description": "Download a video file.\n\nArgs:\n    video_id: Video ID or job ID\n    \nReturns:\n    Video file for download",
+        "operationId": "download_video_api_video_video__video_id__download_get",
+        "parameters": [
+          {
+            "name": "video_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Video Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/{video_id}/thumbnail": {
+      "post": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Generate Video Thumbnail",
+        "description": "Generate thumbnail from video's first frame.\n\nArgs:\n    video_id: Video ID\n    \nReturns:\n    Thumbnail URL or base64 encoded image",
+        "operationId": "generate_video_thumbnail_api_video_video__video_id__thumbnail_post",
+        "parameters": [
+          {
+            "name": "video_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Video Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/heygen/generate": {
+      "post": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Generate Heygen Video",
+        "description": "Genereaz\u0103 un video profesional folosind HeyGen API cu avatar vorbitor.\n\n- **script**: Textul care va fi rostit de avatar (max 1000 caractere)\n- **avatar_id**: ID avatar HeyGen (op\u021bional, folose\u0219te default dac\u0103 lipse\u0219te)\n- **voice_id**: ID voce HeyGen (op\u021bional)\n- **style**: Stilul video (realistic, animated, cartoon, documentary, presentation)\n- **quality**: Calitatea (low, medium, high, ultra)\n- **language**: Limba (ro, en, etc.)\n\nReturns:\n    Dict cu status, video_id \u0219i URL-ul video-ului c\u00e2nd e gata",
+        "operationId": "generate_heygen_video_api_video_video_heygen_generate_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_generate_heygen_video_api_video_video_heygen_generate_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/heygen/status/{video_id}": {
+      "get": {
+        "tags": [
+          "video"
+        ],
+        "summary": "Get Heygen Video Status",
+        "description": "Verific\u0103 statusul unui video HeyGen \u00een curs de generare.\n\n- **video_id**: ID-ul video-ului returnat de /generate\n\nReturns:\n    Status actual \u0219i URL video c\u00e2nd e gata",
+        "operationId": "get_heygen_video_status_api_video_video_heygen_status__video_id__get",
+        "parameters": [
+          {
+            "name": "video_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Video Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/video/heygen/avatars": {
+      "get": {
+        "tags": [
+          "video"
+        ],
+        "summary": "List Heygen Avatars",
+        "description": "Listeaz\u0103 avatarele disponibile \u00een HeyGen.\n\nReturns:\n    List\u0103 de avatare cu ID-uri \u0219i preview-uri",
+        "operationId": "list_heygen_avatars_api_video_video_heygen_avatars_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/conversion/track": {
+      "post": {
+        "tags": [
+          "conversion"
+        ],
+        "summary": "Track Event",
+        "description": "Track a conversion event.\n\nArgs:\n    request: Event tracking data\n    \nReturns:\n    Tracking result",
+        "operationId": "track_event_api_conversion_track_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Track Event Api Conversion Track Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/conversion/stats": {
+      "get": {
+        "tags": [
+          "conversion"
+        ],
+        "summary": "Get Conversion Stats",
+        "description": "Get conversion statistics.\n\nArgs:\n    source: Optional source filter\n    days: Number of days to analyze\n    \nReturns:\n    Conversion statistics",
+        "operationId": "get_conversion_stats_api_conversion_stats_get",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 30,
+              "title": "Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Conversion Stats Api Conversion Stats Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/conversion/top-sources": {
+      "get": {
+        "tags": [
+          "conversion"
+        ],
+        "summary": "Get Top Sources",
+        "description": "Get top performing sources.\n\nArgs:\n    days: Number of days to analyze\n    limit: Max sources to return\n    \nReturns:\n    Top sources",
+        "operationId": "get_top_sources_api_conversion_top_sources_get",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 30,
+              "title": "Days"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 5,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Top Sources Api Conversion Top Sources Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/uploads": {
+      "post": {
+        "summary": "Upload Files",
+        "description": "Upload multiple files to Cloudflare R2 and return their URLs.\n\nEach file is stored under a unique key.  Only files with allowed\nextensions (configured via environment variables) will be uploaded.\n\n:param files: list of UploadFile objects\n:returns: dictionary with list of URLs",
+        "operationId": "upload_files_api_uploads_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_files_api_uploads_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object",
+                  "title": "Response Upload Files Api Uploads Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/autoposter/generate": {
+      "post": {
+        "summary": "Generate Video",
+        "description": "Generate a new promotional video using AI.",
+        "operationId": "generate_video_api_autoposter_generate_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Generate Video Api Autoposter Generate Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/autoposter/publish": {
+      "post": {
+        "summary": "Publish Videos",
+        "description": "Trigger autoposter to publish pending videos.",
+        "operationId": "publish_videos_api_autoposter_publish_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Publish Videos Api Autoposter Publish Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/autoposter/status": {
+      "get": {
+        "summary": "Get Status",
+        "description": "Get autoposter status and list of pending videos.\n\nThis endpoint uses the ``discover_videos`` function imported at\nmodule level (or its fallback) rather than importing the service\nanew. It reads the ``AUTOPOSTER_DIRECTORY`` environment variable to\ndetermine where to look for videos. When the autoposter services\nare stubbed, this simply returns an empty list.",
+        "operationId": "get_status_api_autoposter_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Status Api Autoposter Status Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/test": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Send Test Notification",
+        "description": "Trimite o notificare de test.\n\nArgs:\n    message: Mesajul de trimis\n    background_tasks: Background tasks\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "send_test_notification_api_notify_test_post",
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "Test notificare din Admin",
+              "title": "Message"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Send Test Notification Api Notify Test Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/whatsapp": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Send Whatsapp Notification",
+        "description": "Trimite o notificare pe WhatsApp Business.\n\nArgs:\n    notification_data: Datele notific\u0103rii\n    background_tasks: Background tasks\n\nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "send_whatsapp_notification_api_notify_whatsapp_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Notification Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Send Whatsapp Notification Api Notify Whatsapp Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/email": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Send Email Notification",
+        "description": "Trimite o notificare prin email.\n\nArgs:\n    notification_data: Datele notific\u0103rii\n    background_tasks: Background tasks\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu rezultatul opera\u021biei",
+        "operationId": "send_email_notification_api_notify_email_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Notification Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Send Email Notification Api Notify Email Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/status": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Notification Status",
+        "description": "Ob\u021bine statusul serviciilor de notificare.\n\nArgs:\n    db: Sesiunea de baz\u0103 de date\n    \nReturns:\n    Dic\u021bionar cu statusul serviciilor",
+        "operationId": "get_notification_status_api_notify_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Notification Status Api Notify Status Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/notify/list": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Notifications",
+        "description": "Ob\u021bine lista de notific\u0103ri pentru user.\n\nReturns:\n    List\u0103 cu notific\u0103ri \u0219i count-uri",
+        "operationId": "get_notifications_api_notify_list_get",
+        "parameters": [
+          {
+            "name": "unread_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Doar notific\u0103ri necitite",
+              "default": false,
+              "title": "Unread Only"
+            },
+            "description": "Doar notific\u0103ri necitite"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Num\u0103r maxim de notific\u0103ri",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Num\u0103r maxim de notific\u0103ri"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Notifications Api Notify List Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/mark-read/{notification_id}": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark Notification As Read",
+        "description": "Marcheaz\u0103 o notificare ca citit\u0103.\n\nArgs:\n    notification_id: ID-ul notific\u0103rii\n    \nReturns:\n    Success message",
+        "operationId": "mark_notification_as_read_api_notify_mark_read__notification_id__post",
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Notification Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Mark Notification As Read Api Notify Mark Read  Notification Id  Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/email-templates": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Email Templates",
+        "description": "Get available email templates for notifications.\n\nReturns:\n    List of email templates",
+        "operationId": "get_email_templates_api_notify_email_templates_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Email Templates Api Notify Email Templates Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/notify/email-template": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Send Email With Template",
+        "description": "Send email using a template with variables.\n\nArgs:\n    template_id: ID of the email template\n    recipient_email: Email address of recipient\n    variables: JSON string with template variables\n    background_tasks: Background tasks\n    \nReturns:\n    Success message",
+        "operationId": "send_email_with_template_api_notify_email_template_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_email_with_template_api_notify_email_template_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Send Email With Template Api Notify Email Template Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/email-settings": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Email Settings",
+        "description": "Get email notification settings.\n\nReturns:\n    Email settings configuration",
+        "operationId": "get_email_settings_api_notify_email_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Email Settings Api Notify Email Settings Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Update Email Settings",
+        "description": "Update email notification settings.\n\nArgs:\n    settings: Email settings to update\n    \nReturns:\n    Success message",
+        "operationId": "update_email_settings_api_notify_email_settings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Settings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Update Email Settings Api Notify Email Settings Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/test-template": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Test Email Template",
+        "description": "Send test email using a template.\n\nArgs:\n    template_id: ID of the email template\n    test_email: Email address to send test to\n    background_tasks: Background tasks\n    \nReturns:\n    Success message",
+        "operationId": "test_email_template_api_notify_test_template_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_test_email_template_api_notify_test_template_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Test Email Template Api Notify Test Template Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/sms": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Send Sms Notification",
+        "description": "Send SMS notification.\n\nArgs:\n    phone_number: Phone number to send SMS to\n    message: SMS message content\n    template_id: Optional SMS template ID\n    variables: JSON string with template variables\n    background_tasks: Background tasks\n    \nReturns:\n    Success message",
+        "operationId": "send_sms_notification_api_notify_sms_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_sms_notification_api_notify_sms_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Send Sms Notification Api Notify Sms Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/sms-templates": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Sms Templates",
+        "description": "Get available SMS templates.\n\nReturns:\n    List of SMS templates",
+        "operationId": "get_sms_templates_api_notify_sms_templates_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Sms Templates Api Notify Sms Templates Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/notify/sms-template": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Send Sms With Template",
+        "description": "Send SMS using a template with variables.\n\nArgs:\n    template_id: ID of the SMS template\n    phone_number: Phone number to send SMS to\n    variables: JSON string with template variables\n    background_tasks: Background tasks\n    \nReturns:\n    Success message",
+        "operationId": "send_sms_with_template_api_notify_sms_template_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_send_sms_with_template_api_notify_sms_template_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Send Sms With Template Api Notify Sms Template Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/sms-settings": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Get Sms Settings",
+        "description": "Get SMS notification settings.\n\nReturns:\n    SMS settings configuration",
+        "operationId": "get_sms_settings_api_notify_sms_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Sms Settings Api Notify Sms Settings Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Update Sms Settings",
+        "description": "Update SMS notification settings.\n\nArgs:\n    settings: SMS settings to update\n    \nReturns:\n    Success message",
+        "operationId": "update_sms_settings_api_notify_sms_settings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Settings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Update Sms Settings Api Notify Sms Settings Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notify/test-sms": {
+      "post": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Test Sms Notification",
+        "description": "Send test SMS notification.\n\nArgs:\n    phone_number: Phone number to send test SMS to\n    test_message: Test message content\n    background_tasks: Background tasks\n    \nReturns:\n    Success message",
+        "operationId": "test_sms_notification_api_notify_test_sms_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_test_sms_notification_api_notify_test_sms_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Test Sms Notification Api Notify Test Sms Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/whatsapp/webhook": {
+      "post": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Webhook",
+        "description": "Handle incoming WhatsApp webhook events.",
+        "operationId": "whatsapp_webhook_api_whatsapp_webhook_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Whatsapp Webhook Api Whatsapp Webhook Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/whatsapp/send": {
+      "post": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Send",
+        "description": "Send an outbound WhatsApp message to a user.\n\nBody minim: {\"to\":\"+407...\",\"message\":\"text\"}",
+        "operationId": "whatsapp_send_api_whatsapp_send_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Whatsapp Send Api Whatsapp Send Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/simple-video/generate": {
+      "post": {
+        "tags": [
+          "simple-video"
+        ],
+        "summary": "Generate Simple Video",
+        "description": "Generate a simple video with text overlay.",
+        "operationId": "generate_simple_video_api_simple_video_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimpleVideoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VideoResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/simple-video/list": {
+      "get": {
+        "tags": [
+          "simple-video"
+        ],
+        "summary": "List Generated Videos",
+        "description": "List all generated videos and demo files.",
+        "operationId": "list_generated_videos_api_simple_video_list_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/simple-video/create-demo": {
+      "post": {
+        "tags": [
+          "simple-video"
+        ],
+        "summary": "Create Demo File",
+        "description": "Create a simple demo file to prove the endpoint works.",
+        "operationId": "create_demo_file_api_simple_video_create_demo_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/simple-video/test": {
+      "get": {
+        "tags": [
+          "simple-video"
+        ],
+        "summary": "Test Video Capabilities",
+        "description": "Test video generation capabilities.",
+        "operationId": "test_video_capabilities_api_simple_video_test_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/working-automation/status": {
+      "get": {
+        "tags": [
+          "working-automation"
+        ],
+        "summary": "Get Automation Status",
+        "description": "Get current automation status with real data.",
+        "operationId": "get_automation_status_api_working_automation_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/working-automation/toggle": {
+      "post": {
+        "tags": [
+          "working-automation"
+        ],
+        "summary": "Toggle Automation",
+        "description": "Toggle automation on/off - ACTUALLY WORKS!",
+        "operationId": "toggle_automation_api_working_automation_toggle_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutomationToggleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/working-automation/update-schedule": {
+      "post": {
+        "tags": [
+          "working-automation"
+        ],
+        "summary": "Update Schedule",
+        "description": "Update posting schedule - ACTUALLY WORKS!",
+        "operationId": "update_schedule_api_working_automation_update_schedule_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/working-automation/trigger-post": {
+      "post": {
+        "tags": [
+          "working-automation"
+        ],
+        "summary": "Trigger Manual Post",
+        "description": "Manually trigger a post - ACTUALLY WORKS!",
+        "operationId": "trigger_manual_post_api_working_automation_trigger_post_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/working-automation/recent-actions": {
+      "get": {
+        "tags": [
+          "working-automation"
+        ],
+        "summary": "Get Recent Actions",
+        "description": "Get recent automation actions.",
+        "operationId": "get_recent_actions_api_working_automation_recent_actions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/working-automation/reset-daily-count": {
+      "post": {
+        "tags": [
+          "working-automation"
+        ],
+        "summary": "Reset Daily Post Count",
+        "description": "Reset daily post counter - useful for testing.",
+        "operationId": "reset_daily_post_count_api_working_automation_reset_daily_count_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/professional-video/generate": {
+      "post": {
+        "tags": [
+          "professional-video"
+        ],
+        "summary": "Generate Professional Video",
+        "description": "Generate professional AI video with avatar, lip sync, and backgrounds.",
+        "operationId": "generate_professional_video_api_professional_video_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfessionalVideoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfessionalVideoResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/professional-video/avatars": {
+      "get": {
+        "tags": [
+          "professional-video"
+        ],
+        "summary": "List Available Avatars",
+        "description": "List available avatar styles.",
+        "operationId": "list_available_avatars_api_professional_video_avatars_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/professional-video/backgrounds": {
+      "get": {
+        "tags": [
+          "professional-video"
+        ],
+        "summary": "List Available Backgrounds",
+        "description": "List available background styles.",
+        "operationId": "list_available_backgrounds_api_professional_video_backgrounds_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/professional-video/test-capabilities": {
+      "get": {
+        "tags": [
+          "professional-video"
+        ],
+        "summary": "Test Professional Video Capabilities",
+        "description": "Test professional video generation capabilities.",
+        "operationId": "test_professional_video_capabilities_api_professional_video_test_capabilities_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/advanced-video/generate": {
+      "post": {
+        "tags": [
+          "advanced-video"
+        ],
+        "summary": "Generate Advanced Video",
+        "description": "Generate advanced professional video with AI avatar and backgrounds.",
+        "operationId": "generate_advanced_video_api_advanced_video_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdvancedVideoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdvancedVideoResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/advanced-video/preview/{filename}": {
+      "get": {
+        "tags": [
+          "advanced-video"
+        ],
+        "summary": "Get Video Preview",
+        "description": "Get generated video preview.",
+        "operationId": "get_video_preview_api_advanced_video_preview__filename__get",
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Filename"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/advanced-video/list-generated": {
+      "get": {
+        "tags": [
+          "advanced-video"
+        ],
+        "summary": "List Generated Videos",
+        "description": "List all generated advanced videos and previews.",
+        "operationId": "list_generated_videos_api_advanced_video_list_generated_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/advanced-video/capabilities": {
+      "get": {
+        "tags": [
+          "advanced-video"
+        ],
+        "summary": "Get Advanced Capabilities",
+        "description": "Get advanced video generation capabilities.",
+        "operationId": "get_advanced_capabilities_api_advanced_video_capabilities_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/growth-engine/generate-mass-content": {
+      "post": {
+        "tags": [
+          "Growth Engine"
+        ],
+        "summary": "Generate Mass Content",
+        "description": "Generate viral content at massive scale for simultaneous growth",
+        "operationId": "generate_mass_content_api_growth_engine_generate_mass_content_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MassContentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-engine/growth-analytics": {
+      "get": {
+        "tags": [
+          "Growth Engine"
+        ],
+        "summary": "Get Growth Analytics",
+        "description": "Get real-time growth analytics and performance metrics",
+        "operationId": "get_growth_analytics_api_growth_engine_growth_analytics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-engine/viral-boost": {
+      "post": {
+        "tags": [
+          "Growth Engine"
+        ],
+        "summary": "Activate Viral Boost",
+        "description": "Activate emergency viral content boost for maximum growth",
+        "operationId": "activate_viral_boost_api_growth_engine_viral_boost_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-engine/growth-status": {
+      "get": {
+        "tags": [
+          "Growth Engine"
+        ],
+        "summary": "Get Growth Status",
+        "description": "Get current growth engine status",
+        "operationId": "get_growth_status_api_growth_engine_growth_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/intelligent-conversion/analyze-lead": {
+      "post": {
+        "tags": [
+          "Intelligent Conversion"
+        ],
+        "summary": "Analyze Lead Intelligence",
+        "description": "Analyze lead with AI and generate conversion strategy",
+        "operationId": "analyze_lead_intelligence_api_intelligent_conversion_analyze_lead_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LeadProfile"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/intelligent-conversion/execute-conversion-actions": {
+      "post": {
+        "tags": [
+          "Intelligent Conversion"
+        ],
+        "summary": "Execute Conversion Actions",
+        "description": "Execute automated conversion actions for a lead",
+        "operationId": "execute_conversion_actions_api_intelligent_conversion_execute_conversion_actions_post",
+        "parameters": [
+          {
+            "name": "lead_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Lead Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/intelligent-conversion/conversion-analytics": {
+      "get": {
+        "tags": [
+          "Intelligent Conversion"
+        ],
+        "summary": "Get Conversion Analytics",
+        "description": "Get intelligent conversion analytics",
+        "operationId": "get_conversion_analytics_api_intelligent_conversion_conversion_analytics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/intelligent-conversion/mass-lead-processing": {
+      "post": {
+        "tags": [
+          "Intelligent Conversion"
+        ],
+        "summary": "Process Leads At Scale",
+        "description": "Process all leads with intelligent conversion system",
+        "operationId": "process_leads_at_scale_api_intelligent_conversion_mass_lead_processing_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/intelligent-conversion/system-status": {
+      "get": {
+        "tags": [
+          "Intelligent Conversion"
+        ],
+        "summary": "Get Conversion System Status",
+        "description": "Get intelligent conversion system status",
+        "operationId": "get_conversion_system_status_api_intelligent_conversion_system_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/customer-nurturing/start-nurturing-journey": {
+      "post": {
+        "tags": [
+          "Customer Nurturing"
+        ],
+        "summary": "Start Customer Nurturing",
+        "description": "Start automated customer nurturing journey",
+        "operationId": "start_customer_nurturing_api_customer_nurturing_start_nurturing_journey_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomerProfile"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/customer-nurturing/mass-nurturing-activation": {
+      "post": {
+        "tags": [
+          "Customer Nurturing"
+        ],
+        "summary": "Activate Mass Nurturing",
+        "description": "Activate mass nurturing for all customers",
+        "operationId": "activate_mass_nurturing_api_customer_nurturing_mass_nurturing_activation_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/customer-nurturing/nurturing-analytics": {
+      "get": {
+        "tags": [
+          "Customer Nurturing"
+        ],
+        "summary": "Get Nurturing Analytics",
+        "description": "Get comprehensive nurturing analytics",
+        "operationId": "get_nurturing_analytics_api_customer_nurturing_nurturing_analytics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/customer-nurturing/optimize-nurturing": {
+      "post": {
+        "tags": [
+          "Customer Nurturing"
+        ],
+        "summary": "Optimize Nurturing Campaigns",
+        "description": "AI-powered nurturing optimization",
+        "operationId": "optimize_nurturing_campaigns_api_customer_nurturing_optimize_nurturing_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/customer-nurturing/customer-journey-map": {
+      "get": {
+        "tags": [
+          "Customer Nurturing"
+        ],
+        "summary": "Get Customer Journey Map",
+        "description": "Get visual customer journey mapping",
+        "operationId": "get_customer_journey_map_api_customer_nurturing_customer_journey_map_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/customer-nurturing/nurturing-system-status": {
+      "get": {
+        "tags": [
+          "Customer Nurturing"
+        ],
+        "summary": "Get Nurturing System Status",
+        "description": "Get customer nurturing system status",
+        "operationId": "get_nurturing_system_status_api_customer_nurturing_nurturing_system_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/affiliate-multiplication/create-affiliate": {
+      "post": {
+        "tags": [
+          "Affiliate Multiplication"
+        ],
+        "summary": "Create Affiliate Account",
+        "description": "Create new affiliate account with viral tracking",
+        "operationId": "create_affiliate_account_api_affiliate_multiplication_create_affiliate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffiliateProfile"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/affiliate-multiplication/process-referral": {
+      "post": {
+        "tags": [
+          "Affiliate Multiplication"
+        ],
+        "summary": "Process Viral Referral",
+        "description": "Process referral with viral multiplication tracking",
+        "operationId": "process_viral_referral_api_affiliate_multiplication_process_referral_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferralRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/affiliate-multiplication/affiliate-leaderboard": {
+      "get": {
+        "tags": [
+          "Affiliate Multiplication"
+        ],
+        "summary": "Get Affiliate Leaderboard",
+        "description": "Get top performing affiliates leaderboard",
+        "operationId": "get_affiliate_leaderboard_api_affiliate_multiplication_affiliate_leaderboard_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/affiliate-multiplication/viral-boost-campaign": {
+      "post": {
+        "tags": [
+          "Affiliate Multiplication"
+        ],
+        "summary": "Launch Viral Boost Campaign",
+        "description": "Launch viral boost campaign for explosive growth",
+        "operationId": "launch_viral_boost_campaign_api_affiliate_multiplication_viral_boost_campaign_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/affiliate-multiplication/viral-analytics": {
+      "get": {
+        "tags": [
+          "Affiliate Multiplication"
+        ],
+        "summary": "Get Viral Growth Analytics",
+        "description": "Get comprehensive viral growth analytics",
+        "operationId": "get_viral_growth_analytics_api_affiliate_multiplication_viral_analytics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/affiliate-multiplication/affiliate-system-status": {
+      "get": {
+        "tags": [
+          "Affiliate Multiplication"
+        ],
+        "summary": "Get Affiliate System Status",
+        "description": "Get affiliate multiplication system status",
+        "operationId": "get_affiliate_system_status_api_affiliate_multiplication_affiliate_system_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/dashboard": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Comprehensive Growth Dashboard",
+        "description": "Get comprehensive growth analytics dashboard",
+        "operationId": "get_comprehensive_growth_dashboard_api_growth_analytics_dashboard_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/real-time-metrics": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Real Time Growth Metrics",
+        "description": "Get real-time growth metrics across all systems",
+        "operationId": "get_real_time_growth_metrics_api_growth_analytics_real_time_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/growth-projections": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Growth Projections",
+        "description": "Get AI-powered growth projections and forecasting",
+        "operationId": "get_growth_projections_api_growth_analytics_growth_projections_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/competitive-intelligence": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Competitive Intelligence",
+        "description": "Get competitive intelligence and market positioning",
+        "operationId": "get_competitive_intelligence_api_growth_analytics_competitive_intelligence_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/optimization-recommendations": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Optimization Recommendations",
+        "description": "Get AI-powered optimization recommendations",
+        "operationId": "get_optimization_recommendations_api_growth_analytics_optimization_recommendations_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/roi-analysis": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Roi Analysis",
+        "description": "Get comprehensive ROI analysis of all growth systems",
+        "operationId": "get_roi_analysis_api_growth_analytics_roi_analysis_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/growth-health-score": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Growth Health Score",
+        "description": "Get comprehensive growth health score and system status",
+        "operationId": "get_growth_health_score_api_growth_analytics_growth_health_score_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/growth-analytics/system-status": {
+      "get": {
+        "tags": [
+          "Growth Analytics"
+        ],
+        "summary": "Get Growth Analytics Status",
+        "description": "Get growth analytics system status",
+        "operationId": "get_growth_analytics_status_api_growth_analytics_system_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/master-growth/activate-explosive-growth": {
+      "post": {
+        "tags": [
+          "Master Growth Activation"
+        ],
+        "summary": "Activate Explosive Growth",
+        "description": "\ud83d\ude80 ACTIVATE EXPLOSIVE SIMULTANEOUS GROWTH ACROSS ALL SYSTEMS",
+        "operationId": "activate_explosive_growth_api_master_growth_activate_explosive_growth_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrowthActivationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/master-growth/system-overview": {
+      "get": {
+        "tags": [
+          "Master Growth Activation"
+        ],
+        "summary": "Get Master System Overview",
+        "description": "Get complete overview of the master growth system",
+        "operationId": "get_master_system_overview_api_master_growth_system_overview_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/master-growth/activation-status": {
+      "get": {
+        "tags": [
+          "Master Growth Activation"
+        ],
+        "summary": "Get Activation Status",
+        "description": "Get current activation status of all growth systems",
+        "operationId": "get_activation_status_api_master_growth_activation_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/master-growth/emergency-scale-up": {
+      "post": {
+        "tags": [
+          "Master Growth Activation"
+        ],
+        "summary": "Emergency Scale Up",
+        "description": "\ud83d\udea8 EMERGENCY SCALE-UP - Maximum growth activation",
+        "operationId": "emergency_scale_up_api_master_growth_emergency_scale_up_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/master-growth/growth-ecosystem-summary": {
+      "get": {
+        "tags": [
+          "Master Growth Activation"
+        ],
+        "summary": "Get Growth Ecosystem Summary",
+        "description": "Get complete summary of the growth ecosystem built",
+        "operationId": "get_growth_ecosystem_summary_api_master_growth_growth_ecosystem_summary_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/master-growth/master-status": {
+      "get": {
+        "tags": [
+          "Master Growth Activation"
+        ],
+        "summary": "Get Master System Status",
+        "description": "Get master growth system status",
+        "operationId": "get_master_system_status_api_master_growth_master_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/breakdown": {
+      "get": {
+        "summary": "Financial breakdown",
+        "tags": [
+          "financial"
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Breakdown succes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FinancialBreakdownResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/forecast": {
+      "get": {
+        "summary": "Financial forecast",
+        "tags": [
+          "financial"
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Forecast succes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FinancialForecastResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/cost-categories": {
+      "get": {
+        "summary": "List cost categories",
+        "tags": [
+          "financial"
+        ],
+        "responses": {
+          "200": {
+            "description": "List\u0103 categorii",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CostCategory"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create cost category",
+        "tags": [
+          "financial"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CostCategoryCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Categorie creat\u0103",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostCategory"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/cost-categories/{slug}": {
+      "parameters": [
+        {
+          "name": "slug",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "summary": "Update cost category",
+        "tags": [
+          "financial"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CostCategoryUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Categorie actualizat\u0103",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostCategory"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete cost category",
+        "tags": [
+          "financial"
+        ],
+        "responses": {
+          "200": {
+            "description": "Categorie \u0219tears\u0103",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/costs/{cost_id}/assign-category": {
+      "post": {
+        "summary": "Assign category to cost",
+        "tags": [
+          "financial"
+        ],
+        "parameters": [
+          {
+            "name": "cost_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CostCategoryAssignment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cost actualizat",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/export": {
+      "post": {
+        "summary": "Export financial data",
+        "tags": [
+          "financial"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Fi\u0219ier exportat",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial/invoices/{invoice_id}/export": {
+      "get": {
+        "summary": "Export invoice",
+        "tags": [
+          "financial"
+        ],
+        "parameters": [
+          {
+            "name": "invoice_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pdf",
+                "json"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fi\u0219ier factur\u0103",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AdvancedVideoRequest": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "default": "AutoPro Daune - Exper\u021bii \u00een daune auto. Solu\u021bii rapide \u0219i profesionale pentru toate nevoile tale!"
+          },
+          "duration": {
+            "type": "integer",
+            "title": "Duration",
+            "default": 15
+          },
+          "resolution": {
+            "type": "string",
+            "title": "Resolution",
+            "default": "1080p"
+          },
+          "aspect_ratio": {
+            "type": "string",
+            "title": "Aspect Ratio",
+            "default": "portrait"
+          },
+          "avatar_id": {
+            "type": "string",
+            "title": "Avatar Id",
+            "default": "professional"
+          },
+          "background_id": {
+            "type": "string",
+            "title": "Background Id",
+            "default": "office"
+          },
+          "voice_language": {
+            "type": "string",
+            "title": "Voice Language",
+            "default": "romanian"
+          },
+          "voice_gender": {
+            "type": "string",
+            "title": "Voice Gender",
+            "default": "female"
+          },
+          "enable_subtitles": {
+            "type": "boolean",
+            "title": "Enable Subtitles",
+            "default": true
+          },
+          "enable_lip_sync": {
+            "type": "boolean",
+            "title": "Enable Lip Sync",
+            "default": true
+          },
+          "custom_background_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Background Color",
+            "default": "#1a73e8"
+          },
+          "text_position": {
+            "type": "string",
+            "title": "Text Position",
+            "default": "left"
+          }
+        },
+        "type": "object",
+        "title": "AdvancedVideoRequest"
+      },
+      "AdvancedVideoResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "video_preview_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Preview Path"
+          },
+          "video_config_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Config Path"
+          },
+          "preview_image_base64": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preview Image Base64"
+          },
+          "generation_specs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generation Specs"
+          },
+          "estimated_generation_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Generation Time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "AdvancedVideoResponse"
+      },
+      "AffiliateProfile": {
+        "properties": {
+          "affiliate_id": {
+            "type": "string",
+            "title": "Affiliate Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "phone": {
+            "type": "string",
+            "title": "Phone"
+          },
+          "tier": {
+            "type": "string",
+            "title": "Tier",
+            "default": "bronze"
+          },
+          "referral_count": {
+            "type": "integer",
+            "title": "Referral Count",
+            "default": 0
+          },
+          "total_earnings": {
+            "type": "number",
+            "title": "Total Earnings",
+            "default": 0.0
+          },
+          "conversion_rate": {
+            "type": "number",
+            "title": "Conversion Rate",
+            "default": 0.0
+          },
+          "social_reach": {
+            "type": "integer",
+            "title": "Social Reach",
+            "default": 0
+          },
+          "specialties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Specialties",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "affiliate_id",
+          "name",
+          "email",
+          "phone"
+        ],
+        "title": "AffiliateProfile"
+      },
+      "AutomationSchedule": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          },
+          "posting_times": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Posting Times",
+            "default": [
+              "09:00",
+              "15:00",
+              "21:00"
+            ]
+          },
+          "platforms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Platforms",
+            "default": [
+              "tiktok",
+              "facebook",
+              "instagram"
+            ]
+          },
+          "content_types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Content Types",
+            "default": [
+              "educational",
+              "testimonial",
+              "promotional"
+            ]
+          }
+        },
+        "type": "object",
+        "title": "AutomationSchedule"
+      },
+      "AutomationToggleRequest": {
+        "properties": {
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          }
+        },
+        "type": "object",
+        "required": [
+          "active"
+        ],
+        "title": "AutomationToggleRequest"
+      },
+      "Body_bulk_update_leads_api_leads_bulk_update_post": {
+        "properties": {
+          "lead_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Lead Ids"
+          },
+          "updates": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Updates"
+          }
+        },
+        "type": "object",
+        "required": [
+          "lead_ids",
+          "updates"
+        ],
+        "title": "Body_bulk_update_leads_api_leads_bulk_update_post"
+      },
+      "Body_create_budget_plan_api_financial_budget_plans_post": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "period": {
+            "type": "string",
+            "title": "Period"
+          },
+          "start_date": {
+            "type": "string",
+            "title": "Start Date"
+          },
+          "end_date": {
+            "type": "string",
+            "title": "End Date"
+          },
+          "categories": {
+            "type": "string",
+            "title": "Categories"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "description",
+          "period",
+          "start_date",
+          "end_date",
+          "categories"
+        ],
+        "title": "Body_create_budget_plan_api_financial_budget_plans_post"
+      },
+      "Body_create_invoice_api_financial_invoices_post": {
+        "properties": {
+          "client_name": {
+            "type": "string",
+            "title": "Client Name"
+          },
+          "client_email": {
+            "type": "string",
+            "title": "Client Email"
+          },
+          "client_address": {
+            "type": "string",
+            "title": "Client Address"
+          },
+          "due_date": {
+            "type": "string",
+            "title": "Due Date"
+          },
+          "tax_rate": {
+            "type": "number",
+            "title": "Tax Rate",
+            "default": 0.19
+          },
+          "items": {
+            "type": "string",
+            "title": "Items"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "client_name",
+          "client_email",
+          "client_address",
+          "due_date",
+          "items"
+        ],
+        "title": "Body_create_invoice_api_financial_invoices_post"
+      },
+      "Body_create_payment_api_financial_payments_post": {
+        "properties": {
+          "invoice_id": {
+            "type": "string",
+            "title": "Invoice Id"
+          },
+          "amount": {
+            "type": "number",
+            "title": "Amount"
+          },
+          "payment_method": {
+            "type": "string",
+            "title": "Payment Method"
+          },
+          "payment_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Date"
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "invoice_id",
+          "amount",
+          "payment_method"
+        ],
+        "title": "Body_create_payment_api_financial_payments_post"
+      },
+      "Body_generate_heygen_video_api_video_video_heygen_generate_post": {
+        "properties": {
+          "script": {
+            "type": "string",
+            "title": "Script",
+            "description": "Textul pentru video (max 1000 caractere)"
+          },
+          "avatar_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Id",
+            "description": "ID-ul avatarului HeyGen"
+          },
+          "voice_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Voice Id",
+            "description": "ID-ul vocii"
+          },
+          "style": {
+            "type": "string",
+            "title": "Style",
+            "description": "Stilul video: realistic, animated, cartoon, documentary, presentation",
+            "default": "realistic"
+          },
+          "quality": {
+            "type": "string",
+            "title": "Quality",
+            "description": "Calitatea video: low, medium, high, ultra",
+            "default": "high"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language",
+            "description": "Limba pentru voice-over",
+            "default": "ro"
+          }
+        },
+        "type": "object",
+        "required": [
+          "script"
+        ],
+        "title": "Body_generate_heygen_video_api_video_video_heygen_generate_post"
+      },
+      "Body_generate_manole_video_api_video_video_manole_generate_post": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Script prompt for the video"
+          },
+          "manole_photo": {
+            "type": "string",
+            "format": "binary",
+            "title": "Manole Photo",
+            "description": "Manole's photo to animate"
+          },
+          "accident_footage": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accident Footage",
+            "description": "Accident photos/videos (optional)"
+          },
+          "display_mode": {
+            "type": "string",
+            "title": "Display Mode",
+            "description": "Display mode: sequence, pip, or split",
+            "default": "sequence"
+          },
+          "voice_emotion": {
+            "type": "string",
+            "title": "Voice Emotion",
+            "description": "Voice emotion: professional, empathetic, or urgent",
+            "default": "professional"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt",
+          "manole_photo"
+        ],
+        "title": "Body_generate_manole_video_api_video_video_manole_generate_post"
+      },
+      "Body_send_email_to_lead_api_leads__lead_id__send_email_post": {
+        "properties": {
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template"
+          }
+        },
+        "type": "object",
+        "required": [
+          "subject",
+          "message"
+        ],
+        "title": "Body_send_email_to_lead_api_leads__lead_id__send_email_post"
+      },
+      "Body_send_email_with_template_api_notify_email_template_post": {
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "title": "Template Id"
+          },
+          "recipient_email": {
+            "type": "string",
+            "title": "Recipient Email"
+          },
+          "variables": {
+            "type": "string",
+            "title": "Variables"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_id",
+          "recipient_email",
+          "variables"
+        ],
+        "title": "Body_send_email_with_template_api_notify_email_template_post"
+      },
+      "Body_send_sms_notification_api_notify_sms_post": {
+        "properties": {
+          "phone_number": {
+            "type": "string",
+            "title": "Phone Number"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "template_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Id"
+          },
+          "variables": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Variables"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phone_number",
+          "message"
+        ],
+        "title": "Body_send_sms_notification_api_notify_sms_post"
+      },
+      "Body_send_sms_with_template_api_notify_sms_template_post": {
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "title": "Template Id"
+          },
+          "phone_number": {
+            "type": "string",
+            "title": "Phone Number"
+          },
+          "variables": {
+            "type": "string",
+            "title": "Variables"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_id",
+          "phone_number",
+          "variables"
+        ],
+        "title": "Body_send_sms_with_template_api_notify_sms_template_post"
+      },
+      "Body_test_email_template_api_notify_test_template_post": {
+        "properties": {
+          "template_id": {
+            "type": "string",
+            "title": "Template Id"
+          },
+          "test_email": {
+            "type": "string",
+            "title": "Test Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_id",
+          "test_email"
+        ],
+        "title": "Body_test_email_template_api_notify_test_template_post"
+      },
+      "Body_test_sms_notification_api_notify_test_sms_post": {
+        "properties": {
+          "phone_number": {
+            "type": "string",
+            "title": "Phone Number"
+          },
+          "test_message": {
+            "type": "string",
+            "title": "Test Message",
+            "default": "Test SMS din AutoPro Daune"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phone_number"
+        ],
+        "title": "Body_test_sms_notification_api_notify_test_sms_post"
+      },
+      "Body_upload_files_api_uploads_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
+            "type": "array",
+            "title": "Files"
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "Body_upload_files_api_uploads_post"
+      },
+      "Body_upload_lead_attachment_api_leads_upload_attachment_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          },
+          "lead_id": {
+            "type": "string",
+            "title": "Lead Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file",
+          "lead_id"
+        ],
+        "title": "Body_upload_lead_attachment_api_leads_upload_attachment_post"
+      },
+      "Body_upload_video_for_posting_api_social_upload_video_post": {
+        "properties": {
+          "video": {
+            "type": "string",
+            "format": "binary",
+            "title": "Video"
+          },
+          "caption": {
+            "type": "string",
+            "title": "Caption"
+          },
+          "platforms": {
+            "type": "string",
+            "title": "Platforms"
+          },
+          "scheduled_for": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled For"
+          }
+        },
+        "type": "object",
+        "required": [
+          "video",
+          "caption",
+          "platforms"
+        ],
+        "title": "Body_upload_video_for_posting_api_social_upload_video_post"
+      },
+      "BudgetAlertCreate": {
+        "properties": {
+          "alert_name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Alert Name",
+            "description": "Numele alertei"
+          },
+          "alert_type": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Alert Type",
+            "description": "Tipul alertei"
+          },
+          "threshold_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Threshold Value",
+            "description": "Valoarea pragului"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message",
+            "description": "Mesajul alertei"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "description": "Dac\u0103 alerta este activ\u0103",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "alert_name",
+          "alert_type",
+          "threshold_value"
+        ],
+        "title": "BudgetAlertCreate",
+        "description": "Schema pentru crearea unei alerte de buget."
+      },
+      "BudgetAlertResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "alert_name": {
+            "type": "string",
+            "title": "Alert Name"
+          },
+          "alert_type": {
+            "type": "string",
+            "title": "Alert Type"
+          },
+          "threshold_value": {
+            "type": "string",
+            "title": "Threshold Value"
+          },
+          "current_value": {
+            "type": "string",
+            "title": "Current Value"
+          },
+          "is_triggered": {
+            "type": "boolean",
+            "title": "Is Triggered"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "notification_sent": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notification Sent"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "alert_name",
+          "alert_type",
+          "threshold_value",
+          "current_value",
+          "is_triggered",
+          "is_active",
+          "message",
+          "notification_sent",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "BudgetAlertResponse",
+        "description": "Schema pentru r\u0103spunsul cu date despre alert\u0103."
+      },
+      "CampaignMetricsCreate": {
+        "properties": {
+          "campaign_name": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Campaign Name",
+            "description": "Numele campaniei"
+          },
+          "platform": {
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Platform",
+            "description": "Platforma (ex: TikTok, Instagram)"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date",
+            "title": "Period Start",
+            "description": "\u00cenceputul perioadei"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date",
+            "title": "Period End",
+            "description": "Sf\u00e2r\u0219itul perioadei"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Metadata suplimentar\u0103"
+          }
+        },
+        "type": "object",
+        "required": [
+          "campaign_name",
+          "platform",
+          "period_start",
+          "period_end"
+        ],
+        "title": "CampaignMetricsCreate",
+        "description": "Schema pentru crearea metricilor de campanie."
+      },
+      "CampaignMetricsResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "campaign_name": {
+            "type": "string",
+            "title": "Campaign Name"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date",
+            "title": "Period Start"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date",
+            "title": "Period End"
+          },
+          "total_spent": {
+            "type": "string",
+            "title": "Total Spent"
+          },
+          "cost_per_lead": {
+            "type": "string",
+            "title": "Cost Per Lead"
+          },
+          "cost_per_conversion": {
+            "type": "string",
+            "title": "Cost Per Conversion"
+          },
+          "total_leads": {
+            "type": "integer",
+            "title": "Total Leads"
+          },
+          "total_conversions": {
+            "type": "integer",
+            "title": "Total Conversions"
+          },
+          "conversion_rate": {
+            "type": "string",
+            "title": "Conversion Rate"
+          },
+          "total_views": {
+            "type": "integer",
+            "title": "Total Views"
+          },
+          "total_likes": {
+            "type": "integer",
+            "title": "Total Likes"
+          },
+          "total_shares": {
+            "type": "integer",
+            "title": "Total Shares"
+          },
+          "engagement_rate": {
+            "type": "string",
+            "title": "Engagement Rate"
+          },
+          "total_revenue": {
+            "type": "string",
+            "title": "Total Revenue"
+          },
+          "net_profit": {
+            "type": "string",
+            "title": "Net Profit"
+          },
+          "roi_percentage": {
+            "type": "string",
+            "title": "Roi Percentage"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "campaign_name",
+          "platform",
+          "period_start",
+          "period_end",
+          "total_spent",
+          "cost_per_lead",
+          "cost_per_conversion",
+          "total_leads",
+          "total_conversions",
+          "conversion_rate",
+          "total_views",
+          "total_likes",
+          "total_shares",
+          "engagement_rate",
+          "total_revenue",
+          "net_profit",
+          "roi_percentage",
+          "metadata",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "CampaignMetricsResponse",
+        "description": "Schema pentru r\u0103spunsul cu metrici de campanie."
+      },
+      "ContentCategory": {
+        "type": "string",
+        "enum": [
+          "automotive",
+          "insurance",
+          "education",
+          "promotional",
+          "informational",
+          "entertainment"
+        ],
+        "title": "ContentCategory"
+      },
+      "ContentType": {
+        "type": "string",
+        "enum": [
+          "video",
+          "image",
+          "carousel",
+          "text"
+        ],
+        "title": "ContentType",
+        "description": "Tipurile de con\u021binut suportate."
+      },
+      "CreateContentBody": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "category": {
+            "$ref": "#/components/schemas/ContentCategory",
+            "default": "informational"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentType",
+            "default": "image"
+          },
+          "assets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Assets"
+          },
+          "target_platforms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Target Platforms"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "CreateContentBody"
+      },
+      "CreditBalanceResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "credit_type": {
+            "type": "string",
+            "title": "Credit Type"
+          },
+          "current_balance": {
+            "type": "string",
+            "title": "Current Balance"
+          },
+          "total_allocated": {
+            "type": "string",
+            "title": "Total Allocated"
+          },
+          "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Updated"
+          },
+          "usage_percentage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Usage Percentage"
+          },
+          "remaining_credits": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remaining Credits"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "provider",
+          "credit_type",
+          "current_balance",
+          "total_allocated",
+          "last_updated"
+        ],
+        "title": "CreditBalanceResponse",
+        "description": "Schema pentru r\u0103spunsul cu soldul creditelor."
+      },
+      "CustomerProfile": {
+        "properties": {
+          "customer_id": {
+            "type": "string",
+            "title": "Customer Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "phone": {
+            "type": "string",
+            "title": "Phone"
+          },
+          "current_stage": {
+            "type": "string",
+            "title": "Current Stage",
+            "default": "awareness"
+          },
+          "join_date": {
+            "type": "string",
+            "title": "Join Date"
+          },
+          "interaction_history": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Interaction History",
+            "default": []
+          },
+          "preferences": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Preferences",
+            "default": {}
+          },
+          "lifetime_value": {
+            "type": "number",
+            "title": "Lifetime Value",
+            "default": 0.0
+          }
+        },
+        "type": "object",
+        "required": [
+          "customer_id",
+          "name",
+          "email",
+          "phone",
+          "join_date"
+        ],
+        "title": "CustomerProfile"
+      },
+      "GrowthActivationRequest": {
+        "properties": {
+          "activation_level": {
+            "type": "string",
+            "title": "Activation Level",
+            "default": "explosive"
+          },
+          "target_timeframe": {
+            "type": "string",
+            "title": "Target Timeframe",
+            "default": "30_days"
+          },
+          "growth_multiplier": {
+            "type": "number",
+            "title": "Growth Multiplier",
+            "default": 10.0
+          },
+          "budget_limit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Limit"
+          },
+          "focus_areas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Focus Areas",
+            "default": [
+              "all"
+            ]
+          }
+        },
+        "type": "object",
+        "title": "GrowthActivationRequest"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "JobStatus": {
+        "type": "string",
+        "enum": [
+          "queued",
+          "processing",
+          "completed",
+          "failed",
+          "cancelled"
+        ],
+        "title": "JobStatus"
+      },
+      "LeadActivityCreate": {
+        "properties": {
+          "activity_type": {
+            "type": "string",
+            "title": "Activity Type",
+            "description": "Type: note, email, call, sms, meeting, status_change"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "default": {}
+          },
+          "performed_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Performed By",
+            "default": "system"
+          }
+        },
+        "type": "object",
+        "required": [
+          "activity_type",
+          "description"
+        ],
+        "title": "LeadActivityCreate"
+      },
+      "LeadCreate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "phone_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone Number"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "Lead source: tiktok, facebook, instagram, whatsapp, referral, direct"
+          },
+          "lead_type": {
+            "type": "string",
+            "title": "Lead Type",
+            "description": "Type of lead",
+            "default": "crash_claim"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Lead status",
+            "default": "new"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Details"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "estimated_value": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Value",
+            "default": 0
+          },
+          "priority": {
+            "type": "string",
+            "title": "Priority",
+            "description": "Priority: low, medium, high",
+            "default": "medium"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source"
+        ],
+        "title": "LeadCreate"
+      },
+      "LeadProfile": {
+        "properties": {
+          "lead_id": {
+            "type": "string",
+            "title": "Lead Id"
+          },
+          "contact_info": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Contact Info"
+          },
+          "interaction_history": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Interaction History"
+          },
+          "damage_details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Damage Details"
+          },
+          "urgency_level": {
+            "type": "string",
+            "title": "Urgency Level",
+            "default": "medium"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "unknown"
+          }
+        },
+        "type": "object",
+        "required": [
+          "lead_id",
+          "contact_info",
+          "interaction_history"
+        ],
+        "title": "LeadProfile"
+      },
+      "ManoleGenerateRequest": {
+        "properties": {
+          "topic": {
+            "type": "string",
+            "title": "Topic"
+          },
+          "duration_seconds": {
+            "type": "integer",
+            "title": "Duration Seconds"
+          },
+          "resolution": {
+            "type": "string",
+            "enum": [
+              "720p",
+              "1080p",
+              "4k"
+            ],
+            "title": "Resolution",
+            "default": "1080p"
+          },
+          "bg_type": {
+            "type": "string",
+            "enum": [
+              "color",
+              "image"
+            ],
+            "title": "Bg Type",
+            "default": "color"
+          },
+          "bg_value": {
+            "type": "string",
+            "title": "Bg Value"
+          },
+          "voice_mode": {
+            "type": "string",
+            "title": "Voice Mode",
+            "default": "romanian_tts"
+          },
+          "lipsync": {
+            "type": "boolean",
+            "title": "Lipsync",
+            "default": false
+          },
+          "subtitles": {
+            "type": "boolean",
+            "title": "Subtitles",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "topic",
+          "duration_seconds",
+          "bg_value"
+        ],
+        "title": "ManoleGenerateRequest"
+      },
+      "MassContentRequest": {
+        "properties": {
+          "strategy": {
+            "type": "string",
+            "title": "Strategy",
+            "default": "aggressive_growth"
+          },
+          "content_volume": {
+            "type": "integer",
+            "title": "Content Volume",
+            "default": 50
+          },
+          "platforms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Platforms",
+            "default": [
+              "instagram",
+              "tiktok",
+              "facebook",
+              "linkedin"
+            ]
+          },
+          "languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Languages",
+            "default": [
+              "romanian",
+              "english"
+            ]
+          },
+          "duration_days": {
+            "type": "integer",
+            "title": "Duration Days",
+            "default": 30
+          }
+        },
+        "type": "object",
+        "title": "MassContentRequest"
+      },
+      "ProfessionalVideoRequest": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "default": "AutoPro Daune - Exper\u021bii t\u0103i \u00een daune auto. Rezolv\u0103m rapid \u0219i eficient!"
+          },
+          "duration": {
+            "type": "integer",
+            "title": "Duration",
+            "default": 15
+          },
+          "resolution": {
+            "type": "string",
+            "title": "Resolution",
+            "default": "1080p"
+          },
+          "aspect_ratio": {
+            "type": "string",
+            "title": "Aspect Ratio",
+            "default": "portrait"
+          },
+          "avatar_style": {
+            "type": "string",
+            "title": "Avatar Style",
+            "default": "professional"
+          },
+          "background_type": {
+            "type": "string",
+            "title": "Background Type",
+            "default": "office"
+          },
+          "voice_language": {
+            "type": "string",
+            "title": "Voice Language",
+            "default": "ro"
+          },
+          "voice_gender": {
+            "type": "string",
+            "title": "Voice Gender",
+            "default": "female"
+          },
+          "enable_subtitles": {
+            "type": "boolean",
+            "title": "Enable Subtitles",
+            "default": true
+          },
+          "enable_lip_sync": {
+            "type": "boolean",
+            "title": "Enable Lip Sync",
+            "default": true
+          },
+          "background_color": {
+            "type": "string",
+            "title": "Background Color",
+            "default": "#1a73e8"
+          },
+          "text_color": {
+            "type": "string",
+            "title": "Text Color",
+            "default": "#ffffff"
+          }
+        },
+        "type": "object",
+        "title": "ProfessionalVideoRequest"
+      },
+      "ProfessionalVideoResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "video_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Path"
+          },
+          "thumbnail_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail Path"
+          },
+          "file_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Size"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration"
+          },
+          "specs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "ProfessionalVideoResponse"
+      },
+      "ROIAnalysisResponse": {
+        "properties": {
+          "period": {
+            "type": "string",
+            "title": "Period"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "total_costs": {
+            "type": "string",
+            "title": "Total Costs"
+          },
+          "total_revenue": {
+            "type": "string",
+            "title": "Total Revenue"
+          },
+          "net_profit": {
+            "type": "string",
+            "title": "Net Profit"
+          },
+          "roi_percentage": {
+            "type": "string",
+            "title": "Roi Percentage"
+          },
+          "cost_breakdown": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Cost Breakdown"
+          },
+          "revenue_breakdown": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Revenue Breakdown"
+          },
+          "cost_change_percentage": {
+            "type": "string",
+            "title": "Cost Change Percentage"
+          },
+          "revenue_change_percentage": {
+            "type": "string",
+            "title": "Revenue Change Percentage"
+          },
+          "profit_change_percentage": {
+            "type": "string",
+            "title": "Profit Change Percentage"
+          },
+          "roi_change_percentage": {
+            "type": "string",
+            "title": "Roi Change Percentage"
+          },
+          "recommendations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Recommendations"
+          },
+          "timeline": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTimelinePoint"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "period",
+          "start_date",
+          "end_date",
+          "total_costs",
+          "total_revenue",
+          "net_profit",
+          "roi_percentage",
+          "cost_breakdown",
+          "revenue_breakdown",
+          "cost_change_percentage",
+          "revenue_change_percentage",
+          "profit_change_percentage",
+          "roi_change_percentage",
+          "recommendations"
+        ],
+        "title": "ROIAnalysisResponse",
+        "description": "Schema pentru r\u0103spunsul cu analiza ROI."
+      },
+      "ReferralRequest": {
+        "properties": {
+          "referrer_id": {
+            "type": "string",
+            "title": "Referrer Id"
+          },
+          "referee_name": {
+            "type": "string",
+            "title": "Referee Name"
+          },
+          "referee_email": {
+            "type": "string",
+            "title": "Referee Email"
+          },
+          "referee_phone": {
+            "type": "string",
+            "title": "Referee Phone"
+          },
+          "damage_estimate": {
+            "type": "number",
+            "title": "Damage Estimate"
+          },
+          "referral_source": {
+            "type": "string",
+            "title": "Referral Source"
+          },
+          "campaign_type": {
+            "type": "string",
+            "title": "Campaign Type",
+            "default": "friend_reward"
+          }
+        },
+        "type": "object",
+        "required": [
+          "referrer_id",
+          "referee_name",
+          "referee_email",
+          "referee_phone",
+          "damage_estimate",
+          "referral_source"
+        ],
+        "title": "ReferralRequest"
+      },
+      "RetryRequest": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id"
+        ],
+        "title": "RetryRequest"
+      },
+      "ScheduleUpdateRequest": {
+        "properties": {
+          "schedule": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Schedule"
+          },
+          "daily_target": {
+            "type": "integer",
+            "title": "Daily Target",
+            "default": 3
+          }
+        },
+        "type": "object",
+        "required": [
+          "schedule"
+        ],
+        "title": "ScheduleUpdateRequest"
+      },
+      "SimpleVideoRequest": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "default": "AutoPro Daune - Rezolv\u0103 daunele rapid \u0219i simplu!"
+          },
+          "duration": {
+            "type": "integer",
+            "title": "Duration",
+            "default": 10
+          },
+          "width": {
+            "type": "integer",
+            "title": "Width",
+            "default": 720
+          },
+          "height": {
+            "type": "integer",
+            "title": "Height",
+            "default": 480
+          },
+          "background_color": {
+            "type": "string",
+            "title": "Background Color",
+            "default": "#1a73e8"
+          },
+          "text_color": {
+            "type": "string",
+            "title": "Text Color",
+            "default": "#ffffff"
+          }
+        },
+        "type": "object",
+        "title": "SimpleVideoRequest"
+      },
+      "TrackEventRequest": {
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "title": "Event Type"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "lead_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lead Id"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_type",
+          "source"
+        ],
+        "title": "TrackEventRequest"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VideoGenerateRequest": {
+        "properties": {
+          "template": {
+            "type": "string",
+            "title": "Template"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "duration": {
+            "type": "integer",
+            "title": "Duration",
+            "default": 30
+          },
+          "resolution": {
+            "type": "string",
+            "enum": [
+              "720p",
+              "1080p",
+              "4k"
+            ],
+            "title": "Resolution",
+            "default": "1080p"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template",
+          "text"
+        ],
+        "title": "VideoGenerateRequest"
+      },
+      "VideoGenerationRequest": {
+        "properties": {
+          "template_type": {
+            "type": "string",
+            "title": "Template Type",
+            "description": "Type: educational, testimonial, promotional"
+          },
+          "target_platforms": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Target Platforms",
+            "default": [
+              "tiktok",
+              "facebook",
+              "instagram"
+            ]
+          },
+          "scheduled_for": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled For"
+          }
+        },
+        "type": "object",
+        "required": [
+          "template_type"
+        ],
+        "title": "VideoGenerationRequest"
+      },
+      "VideoResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "video_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Video Path"
+          },
+          "file_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Size"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "VideoResponse"
+      },
+      "WorkingLeadCreate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "phone_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone Number"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "direct"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "title": "WorkingLeadCreate"
+      },
+      "FinancialTimelinePoint": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "revenue": {
+            "type": "number"
+          },
+          "costs": {
+            "type": "number"
+          },
+          "profit": {
+            "type": "number"
+          },
+          "cumulative_profit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "date",
+          "revenue",
+          "costs",
+          "profit"
+        ],
+        "description": "Punct de timeline financiar"
+      },
+      "FinancialBreakdownResponse": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "costs": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number"
+              },
+              "by_category": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "by_provider": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "top": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "provider": {
+                      "type": "string"
+                    },
+                    "operation": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "revenue": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number"
+              },
+              "by_category": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "by_source": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "top": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "source": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "timeline": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTimelinePoint"
+            }
+          },
+          "profitability": {
+            "type": "object",
+            "properties": {
+              "net_profit": {
+                "type": "number"
+              },
+              "roi": {
+                "type": "number"
+              },
+              "profit_margin": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "FinancialForecastResponse": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "averages": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "growth_rates": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "forecasts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "revenue": {
+                  "type": "number"
+                },
+                "costs": {
+                  "type": "number"
+                },
+                "profit": {
+                  "type": "number"
+                },
+                "trend": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "series": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTimelinePoint"
+            }
+          }
+        }
+      },
+      "CostCategory": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "budget_cap": {
+            "type": "number"
+          },
+          "color": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "slug",
+          "name"
+        ]
+      },
+      "CostCategoryCreate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "budget_cap": {
+            "type": "number"
+          },
+          "color": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "CostCategoryUpdate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "budget_cap": {
+            "type": "number"
+          },
+          "color": {
+            "type": "string"
+          }
+        }
+      },
+      "CostCategoryAssignment": {
+        "type": "object",
+        "properties": {
+          "category_slug": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "category_slug"
+        ]
+      },
+      "ProfitLossResponse": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "total_costs": {
+            "type": "number"
+          },
+          "total_revenue": {
+            "type": "number"
+          },
+          "net_profit": {
+            "type": "number"
+          },
+          "roi_percentage": {
+            "type": "number"
+          },
+          "cost_breakdown": {
+            "type": "object"
+          },
+          "revenue_breakdown": {
+            "type": "object"
+          },
+          "daily_metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinancialTimelinePoint"
+            }
+          },
+          "cost_categories": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "revenue_categories": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "avg_daily_profit": {
+            "type": "number"
+          },
+          "best_day_profit": {
+            "type": "number"
+          },
+          "worst_day_profit": {
+            "type": "number"
+          },
+          "profit_volatility": {
+            "type": "number"
+          },
+          "recommendations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ExportRequest": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string",
+            "enum": [
+              "csv",
+              "excel",
+              "json"
+            ]
+          },
+          "period": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "include_costs": {
+            "type": "boolean"
+          },
+          "include_revenue": {
+            "type": "boolean"
+          },
+          "include_metrics": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "format"
+        ],
+        "description": "Cerere pentru export financiar"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/services/api/app/routes/financial.py
+++ b/services/api/app/routes/financial.py
@@ -8,11 +8,16 @@ Acest modul implementează endpoint-urile REST pentru:
 - Dashboard financiar
 """
 
+import csv
+import io
+import json
 import logging
+import uuid
 from datetime import datetime, date, timedelta
 from decimal import Decimal
 from typing import Dict, Any, Optional, List
 from fastapi import APIRouter, Depends, HTTPException, Query, Path, Body, Form
+from fastapi.responses import Response, StreamingResponse
 
 from ..database import get_db
 from ..models import CampaignMetrics
@@ -31,9 +36,12 @@ roi_calculator = ROICalculator()
 from ..schemas.financial import (
     APICostCreate, RevenueCreate, FinancialMetricsCreate,
     ROIAnalysisResponse, ProfitLossResponse, FinancialDashboardResponse,
+    FinancialBreakdownResponse, FinancialForecastResponse,
     CampaignMetricsCreate, CampaignMetricsResponse,
     CreditBalanceUpdate, CreditBalanceResponse,
-    BudgetAlertCreate, BudgetAlertResponse
+    BudgetAlertCreate, BudgetAlertResponse,
+    CostCategory, CostCategoryCreate, CostCategoryUpdate, CostCategoryAssignment,
+    ExportRequest
 )
 
 
@@ -303,6 +311,180 @@ async def get_roi_analysis(
         raise HTTPException(status_code=500, detail=f"Eroare la analiza ROI: {str(e)}")
 
 
+@router.get("/breakdown", response_model=FinancialBreakdownResponse)
+async def get_financial_breakdown(
+    period: str = Query("30d", description="Perioada preset pentru breakdown"),
+    date_from: Optional[str] = Query(None, description="Data start custom"),
+    date_to: Optional[str] = Query(None, description="Data end custom")
+):
+    """Returnează breakdown detaliat pe costuri și venituri."""
+    try:
+        return ft.financial_breakdown(period=period, date_from=date_from, date_to=date_to)
+    except Exception as e:
+        logging.error(f"Eroare la breakdown financiar: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la breakdown: {str(e)}")
+
+
+@router.get("/forecast", response_model=FinancialForecastResponse)
+async def get_financial_forecast(
+    period: str = Query("60d", description="Perioada utilizată pentru calculul forecast-ului"),
+    date_from: Optional[str] = Query(None, description="Data start custom"),
+    date_to: Optional[str] = Query(None, description="Data end custom")
+):
+    """Returnează forecast simplificat pentru venituri/costuri/profit."""
+    try:
+        return ft.financial_forecast(period=period, date_from=date_from, date_to=date_to)
+    except Exception as e:
+        logging.error(f"Eroare la forecast financiar: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la forecast: {str(e)}")
+
+
+# ==================== COST CATEGORY MANAGEMENT ====================
+
+@router.get("/cost-categories", response_model=List[CostCategory])
+async def list_cost_categories():
+    """List all cost categories (custom + default fallbacks)."""
+    try:
+        categories = ft.list_cost_categories()
+        return categories
+    except Exception as e:
+        logging.error(f"Eroare la listarea categoriilor de cost: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la listare categorii: {str(e)}")
+
+
+@router.post("/cost-categories", response_model=CostCategory)
+async def create_cost_category(category: CostCategoryCreate):
+    try:
+        result = ft.create_cost_category(category.dict())
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logging.error(f"Eroare la crearea categoriei: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la crearea categoriei: {str(e)}")
+
+
+@router.put("/cost-categories/{slug}", response_model=CostCategory)
+async def update_cost_category(slug: str, updates: CostCategoryUpdate):
+    try:
+        ft.update_cost_category(slug, updates.dict(exclude_unset=True))
+        categories = ft.list_cost_categories()
+        for cat in categories:
+            if cat.get("slug") == slug:
+                return cat
+        raise HTTPException(status_code=404, detail="Categoria nu a fost găsită după actualizare")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logging.error(f"Eroare la actualizarea categoriei: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la actualizarea categoriei: {str(e)}")
+
+
+@router.delete("/cost-categories/{slug}")
+async def delete_cost_category(slug: str) -> Dict[str, Any]:
+    try:
+        ft.delete_cost_category(slug)
+        return {"success": True, "slug": slug}
+    except Exception as e:
+        logging.error(f"Eroare la ștergerea categoriei: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la ștergerea categoriei: {str(e)}")
+
+
+@router.post("/costs/{cost_id}/assign-category")
+async def assign_cost_category(cost_id: int, assignment: CostCategoryAssignment) -> Dict[str, Any]:
+    try:
+        result = ft.assign_cost_category(cost_id, assignment.category_slug)
+        return {"success": True, "data": result}
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logging.error(f"Eroare la asignarea categoriei: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la asignarea categoriei: {str(e)}")
+
+
+@router.post("/export")
+async def export_financial_data(export_request: ExportRequest):
+    """Exportă date financiare în format CSV/JSON."""
+    try:
+        data = ft.export_financial_data(
+            period=export_request.period or "30d",
+            date_from=export_request.start_date.isoformat() if export_request.start_date else None,
+            date_to=export_request.end_date.isoformat() if export_request.end_date else None,
+            include_costs=export_request.include_costs,
+            include_revenue=export_request.include_revenue,
+        )
+
+        filename_base = f"financial-export-{datetime.now().strftime('%Y%m%d-%H%M')}"
+        export_format = export_request.format.lower()
+
+        if export_format == "json":
+            payload = json.dumps(data, default=str, ensure_ascii=False, indent=2).encode("utf-8")
+            return Response(
+                content=payload,
+                media_type="application/json",
+                headers={"Content-Disposition": f"attachment; filename={filename_base}.json"}
+            )
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+
+        metrics = data.get("metrics", {}) or {}
+        if export_request.include_metrics:
+            writer.writerow(["METRICS", "Field", "Value"])
+            for key in ("total_revenue", "total_costs", "net_profit", "roi_percentage"):
+                writer.writerow(["summary", key, metrics.get(key)])
+            writer.writerow([])
+
+        if export_request.include_costs:
+            writer.writerow(["COSTS", "Provider", "Operation", "Category", "Amount", "Timestamp"])
+            for cost in data.get("costs", []) or []:
+                metadata = cost.get("metadata") or {}
+                if isinstance(metadata, str):
+                    try:
+                        metadata = json.loads(metadata)
+                    except json.JSONDecodeError:
+                        metadata = {}
+                writer.writerow([
+                    "cost",
+                    cost.get("provider"),
+                    cost.get("operation"),
+                    metadata.get("category") or metadata.get("cost_category"),
+                    cost.get("cost"),
+                    cost.get("timestamp"),
+                ])
+            writer.writerow([])
+
+        if export_request.include_revenue:
+            writer.writerow(["REVENUE", "Source", "Category", "Amount", "Timestamp"])
+            for revenue in data.get("revenues", []) or []:
+                metadata = revenue.get("metadata") or {}
+                if isinstance(metadata, str):
+                    try:
+                        metadata = json.loads(metadata)
+                    except json.JSONDecodeError:
+                        metadata = {}
+                writer.writerow([
+                    "revenue",
+                    revenue.get("source"),
+                    metadata.get("category") or metadata.get("revenue_category"),
+                    revenue.get("amount"),
+                    revenue.get("timestamp"),
+                ])
+
+        csv_content = output.getvalue().encode("utf-8")
+        return Response(
+            content=csv_content,
+            media_type="text/csv",
+            headers={"Content-Disposition": f"attachment; filename={filename_base}.csv"}
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logging.error(f"Eroare la exportul datelor financiare: {e}")
+        raise HTTPException(status_code=500, detail=f"Eroare la export: {str(e)}")
+
+
 # ==================== PAYMENT TRACKING ENDPOINTS ====================
 
 @router.get("/payments")
@@ -522,8 +704,6 @@ async def create_invoice(
 ) -> Dict[str, Any]:
     """Create a new invoice."""
     try:
-        import json
-        
         # Parse items
         try:
             invoice_items = json.loads(items)
@@ -572,6 +752,34 @@ async def create_invoice(
         raise HTTPException(status_code=500, detail=f"Failed to create invoice: {str(e)}")
 
 
+@router.get("/invoices/{invoice_id}/export")
+async def export_invoice(
+    invoice_id: str,
+    format: str = Query("pdf", description="Formatul exportului (pdf/json)")
+):
+    """Exportă o factură în format PDF simplificat sau JSON."""
+    try:
+        pdf_bytes, invoice = ft.generate_invoice_pdf(invoice_id)
+        if format.lower() == "json":
+            return Response(
+                content=json.dumps(invoice, default=str, ensure_ascii=False, indent=2).encode("utf-8"),
+                media_type="application/json",
+                headers={"Content-Disposition": f"attachment; filename=invoice-{invoice_id}.json"}
+            )
+
+        return Response(
+            content=pdf_bytes,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f"attachment; filename=invoice-{invoice_id}.pdf"}
+        )
+
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.error(f"[InvoiceGeneration] Export invoice error: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to export invoice: {str(e)}")
+
+
 # ==================== BUDGET PLANNING ENDPOINTS ====================
 
 @router.get("/budget-plans")
@@ -609,8 +817,6 @@ async def create_budget_plan(
 ) -> Dict[str, Any]:
     """Create a new budget plan."""
     try:
-        import json
-        
         # Parse categories
         try:
             budget_categories = json.loads(categories)
@@ -650,7 +856,7 @@ async def create_budget_plan(
         raise HTTPException(status_code=500, detail=f"Failed to create budget plan: {str(e)}")
 
 
-@router.get("/profit-loss")
+@router.get("/profit-loss", response_model=ProfitLossResponse)
 async def get_profit_loss(
     start_date: date = Query(..., description="Data de început"),
     end_date: date = Query(..., description="Data de sfârșit")
@@ -668,10 +874,14 @@ async def get_profit_loss(
     try:
         if start_date > end_date:
             raise HTTPException(status_code=400, detail="Data de început nu poate fi mai mare decât data de sfârșit")
-        
-        days = (end_date - start_date).days
+
+        days = (end_date - start_date).days or 1
         period = f"{days}d"
-        return ft.profit_loss_between(period)
+        return ft.profit_loss_report(
+            period=period,
+            date_from=start_date.isoformat(),
+            date_to=end_date.isoformat(),
+        )
         
     except HTTPException:
         raise

--- a/services/api/app/schemas/financial.py
+++ b/services/api/app/schemas/financial.py
@@ -8,7 +8,69 @@ pentru endpoint-urile API financiare.
 from datetime import datetime, date as Date
 from decimal import Decimal
 from typing import Optional, Dict, Any, List
+
 from pydantic import BaseModel, Field, validator, model_validator
+
+
+# ==================== SCHEME GENERALE ====================
+
+class FinancialTimelinePoint(BaseModel):
+    date: str = Field(..., description="Data în format YYYY-MM-DD")
+    revenue: float
+    costs: float
+    profit: float
+    cumulative_profit: Optional[float] = None
+
+
+class BreakdownCostItem(BaseModel):
+    id: Optional[Any] = None
+    provider: Optional[str] = None
+    operation: Optional[str] = None
+    category: Optional[str] = None
+    amount: float
+    timestamp: Optional[str] = None
+
+
+class BreakdownRevenueItem(BaseModel):
+    id: Optional[Any] = None
+    source: Optional[str] = None
+    category: Optional[str] = None
+    amount: float
+    timestamp: Optional[str] = None
+
+
+class ProfitabilitySummary(BaseModel):
+    net_profit: float
+    roi: float
+    profit_margin: float
+
+
+class FinancialBreakdownResponse(BaseModel):
+    period: str
+    start_date: Optional[Date]
+    end_date: Optional[Date]
+    costs: Dict[str, Any]
+    revenue: Dict[str, Any]
+    timeline: List[FinancialTimelinePoint]
+    profitability: ProfitabilitySummary
+
+
+class ForecastEntry(BaseModel):
+    revenue: float
+    costs: float
+    profit: float
+    trend: str
+
+
+class FinancialForecastResponse(BaseModel):
+    period: str
+    start_date: Optional[Date]
+    end_date: Optional[Date]
+    averages: Dict[str, float]
+    growth_rates: Dict[str, float]
+    forecasts: Dict[str, ForecastEntry]
+    confidence: float
+    series: List[FinancialTimelinePoint]
 
 
 # ==================== SCHEME DE BAZĂ ====================
@@ -251,6 +313,36 @@ class BudgetAlertResponse(BaseModel):
         from_attributes = True
 
 
+# ==================== SCHEME PENTRU CATEGORII DE COST ====================
+
+class CostCategory(BaseModel):
+    slug: str
+    name: str
+    description: Optional[str] = None
+    budget_cap: Optional[Decimal] = None
+    color: Optional[str] = None
+    is_default: Optional[bool] = False
+
+
+class CostCategoryCreate(BaseModel):
+    name: str = Field(..., description="Numele categoriei")
+    description: Optional[str] = Field(None, description="Descriere scurtă")
+    budget_cap: Optional[Decimal] = Field(None, description="Bugetul alocat")
+    color: Optional[str] = Field(None, description="Codul de culoare hex")
+    slug: Optional[str] = Field(None, description="Identificator unic (opțional)")
+
+
+class CostCategoryUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    budget_cap: Optional[Decimal] = None
+    color: Optional[str] = None
+
+
+class CostCategoryAssignment(BaseModel):
+    category_slug: str = Field(..., min_length=1, description="Slug-ul categoriei de cost")
+
+
 # ==================== SCHEME PENTRU DASHBOARD ====================
 
 class FinancialDashboardResponse(BaseModel):
@@ -277,15 +369,24 @@ class FinancialDashboardResponse(BaseModel):
     cost_trend: str  # "up", "down", "stable"
     revenue_trend: str
     profit_trend: str
-    
+
     # Alerte active
     active_alerts: List[BudgetAlertResponse]
-    
+
     # Top costuri
     top_cost_providers: List[Dict[str, Any]]
-    
+
     # Top surse de venit
     top_revenue_sources: List[Dict[str, Any]]
+
+    # Breakdown detaliat
+    timeline: List[FinancialTimelinePoint] = Field(default_factory=list)
+    cost_breakdown: Dict[str, Any] = Field(default_factory=dict)
+    revenue_breakdown: Dict[str, Any] = Field(default_factory=dict)
+    profit_margin: Decimal = Field(0, description="Marja de profit")
+    average_daily_profit: Decimal = Field(0, description="Profitul mediu zilnic")
+    cost_categories: Dict[str, Decimal] = Field(default_factory=dict)
+    revenue_categories: Dict[str, Decimal] = Field(default_factory=dict)
 
 
 class ROIAnalysisRequest(BaseModel):
@@ -325,11 +426,12 @@ class ROIAnalysisResponse(BaseModel):
     total_revenue: Decimal
     net_profit: Decimal
     roi_percentage: Decimal
-    
+
     # Metrici detaliate
-    cost_breakdown: Dict[str, Decimal]
-    revenue_breakdown: Dict[str, Decimal]
-    
+    cost_breakdown: Dict[str, Any]
+    revenue_breakdown: Dict[str, Any]
+    timeline: List[FinancialTimelinePoint] = Field(default_factory=list)
+
     # Comparații cu perioada anterioară
     cost_change_percentage: Decimal
     revenue_change_percentage: Decimal
@@ -363,27 +465,31 @@ class ProfitLossRequest(BaseModel):
 
 class ProfitLossResponse(BaseModel):
     """Schema pentru răspunsul cu analiza profit/pierdere."""
-    start_date: Date
-    end_date: Date
-    
+    period: str
+    start_date: Optional[Date]
+    end_date: Optional[Date]
+
     # Totale
     total_costs: Decimal
     total_revenue: Decimal
     net_profit: Decimal
     roi_percentage: Decimal
-    
-    # Breakdown zilnic
-    daily_metrics: List[Dict[str, Any]]
-    
+
+    # Breakdown detaliat
+    cost_breakdown: Dict[str, Any]
+    revenue_breakdown: Dict[str, Any]
+    daily_metrics: List[FinancialTimelinePoint]
+
     # Breakdown pe categorii
     cost_categories: Dict[str, Decimal]
     revenue_categories: Dict[str, Decimal]
-    
+
     # Statistici
     avg_daily_profit: Decimal
     best_day_profit: Decimal
     worst_day_profit: Decimal
     profit_volatility: Decimal
+    recommendations: List[str] = Field(default_factory=list)
 
 
 # ==================== SCHEME PENTRU BULK OPERATIONS ====================
@@ -446,6 +552,7 @@ class FinancialStatsResponse(BaseModel):
 class ExportRequest(BaseModel):
     """Schema pentru cererea de export date financiare."""
     format: str = Field(..., description="Formatul de export: 'csv', 'excel', 'json'")
+    period: Optional[str] = Field("30d", description="Perioada presetată pentru export")
     start_date: Optional[Date] = Field(None, description="Data de început")
     end_date: Optional[Date] = Field(None, description="Data de sfârșit")
     include_costs: bool = Field(True, description="Include costurile")
@@ -459,6 +566,12 @@ class ExportRequest(BaseModel):
         if v.lower() not in valid_formats:
             raise ValueError(f'Format invalid: {v}. Formate valide: {valid_formats}')
         return v.lower()
+
+    @model_validator(mode='after')
+    def validate_inclusions(self):
+        if not any([self.include_costs, self.include_revenue, self.include_metrics]):
+            raise ValueError('Trebuie selectată cel puțin o categorie pentru export')
+        return self
 
 
 class ExportResponse(BaseModel):

--- a/services/api/app/services/financial/service.py
+++ b/services/api/app/services/financial/service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 from typing import Any, Dict, Optional, List, Tuple
+from collections import defaultdict
+from statistics import mean, pstdev
 from datetime import datetime, timezone
+import json
 import logging
 
 from .utils import period_bounds, normalize_provider
@@ -12,6 +15,39 @@ COSTS_TABLE    = "api_costs"            # tabelul existent
 REVENUE_TABLE  = "revenues"
 CREDIT_TABLE   = "credit_balances"
 ALERTS_TABLE   = "budget_alerts"
+COST_CATEGORY_TABLE = "cost_categories"
+INVOICE_TABLE = "invoices"
+
+DEFAULT_COST_CATEGORIES = [
+    {
+        "slug": "ai_automation",
+        "name": "AI & Automation",
+        "description": "Costuri pentru modele AI, generare video și automatizări",
+        "budget_cap": 2500.0,
+        "color": "#2563eb",
+    },
+    {
+        "slug": "marketing",
+        "name": "Marketing & Paid Media",
+        "description": "Campanii plătite, reclame și funnel automation",
+        "budget_cap": 1800.0,
+        "color": "#f97316",
+    },
+    {
+        "slug": "operations",
+        "name": "Operațional",
+        "description": "Licențe, infrastructură, suport și tool-uri back-office",
+        "budget_cap": 1200.0,
+        "color": "#16a34a",
+    },
+    {
+        "slug": "referrals",
+        "name": "Referral Rewards",
+        "description": "Bonusuri și comisioane pentru parteneri și clienți",
+        "budget_cap": 1500.0,
+        "color": "#9333ea",
+    },
+]
 
 class FinancialService:
     """
@@ -21,6 +57,108 @@ class FinancialService:
 
     def __init__(self, supabase_service):
         self.db = supabase_service
+
+    # ----------------- HELPERE INTERNE -----------------
+    def _prepare_period_filters(
+        self,
+        period: str,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Tuple[Optional[str], Optional[str], List[Tuple[str, str, Any]]]:
+        """Returnează start/end ISO și filtre pentru interogările Supabase."""
+
+        if date_from and date_to:
+            start = f"{date_from}T00:00:00Z"
+            end = f"{date_to}T23:59:59Z"
+        else:
+            start, end = period_bounds(period)
+
+        filters: List[Tuple[str, str, Any]] = []
+        if start:
+            filters.append(("gte", "timestamp", start))
+        if end:
+            filters.append(("lte", "timestamp", end))
+        return start, end, filters
+
+    @staticmethod
+    def _parse_metadata(raw: Any) -> Dict[str, Any]:
+        """Normalizează metadata venită fie ca dict, fie ca JSON string."""
+
+        if not raw:
+            return {}
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                data = json.loads(raw)
+                if isinstance(data, dict):
+                    return data
+            except json.JSONDecodeError:
+                pass
+        return {}
+
+    @staticmethod
+    def _safe_div(numerator: float, denominator: float) -> float:
+        return numerator / denominator if denominator else 0.0
+
+    def _build_daily_series(
+        self,
+        costs: List[Dict[str, Any]],
+        revenues: List[Dict[str, Any]],
+    ) -> List[Dict[str, float]]:
+        """Agregă costuri/venituri pe zile pentru grafice și forecast."""
+
+        daily = defaultdict(lambda: {"revenue": 0.0, "costs": 0.0})
+
+        for cost in costs:
+            try:
+                amount = float(cost.get("cost") or cost.get("amount") or 0.0)
+            except (TypeError, ValueError):
+                amount = 0.0
+            timestamp = cost.get("timestamp") or ""
+            day = timestamp[:10] if timestamp else datetime.now(timezone.utc).date().isoformat()
+            daily[day]["costs"] += amount
+
+        for rev in revenues:
+            try:
+                amount = float(rev.get("amount") or 0.0)
+            except (TypeError, ValueError):
+                amount = 0.0
+            timestamp = rev.get("timestamp") or ""
+            day = timestamp[:10] if timestamp else datetime.now(timezone.utc).date().isoformat()
+            daily[day]["revenue"] += amount
+
+        series = []
+        for day in sorted(daily.keys()):
+            revenue = daily[day]["revenue"]
+            costs_val = daily[day]["costs"]
+            series.append(
+                {
+                    "date": day,
+                    "revenue": round(revenue, 2),
+                    "costs": round(costs_val, 2),
+                    "profit": round(revenue - costs_val, 2),
+                }
+            )
+        return series
+
+    def _get_cost_category(self, cost: Dict[str, Any]) -> str:
+        meta = self._parse_metadata(cost.get("metadata") or cost.get("meta"))
+        category = (
+            meta.get("category")
+            or meta.get("cost_category")
+            or cost.get("operation")
+            or cost.get("provider")
+            or "other"
+        )
+        return str(category).strip() or "other"
+
+    def _get_revenue_category(self, revenue: Dict[str, Any]) -> str:
+        meta = self._parse_metadata(revenue.get("metadata") or revenue.get("meta"))
+        category = meta.get("category") or meta.get("revenue_category") or revenue.get("source")
+        return str(category or "other").strip() or "other"
+
+    # ----------------- COSTURI API -----------------
 
     # ----------------- COSTURI API -----------------
     def track_api_cost(self, *, provider: str, amount: float, currency: str = "EUR",
@@ -115,27 +253,51 @@ class FinancialService:
 
     # ----------------- ANALITICE -----------------
     def roi_analysis(self, period: str = "7d", date_from: Optional[str] = None, date_to: Optional[str] = None) -> Dict[str, Any]:
-        # Use custom dates if provided, otherwise use period
-        if date_from and date_to:
-            start = f"{date_from}T00:00:00Z"
-            end = f"{date_to}T23:59:59Z"
-        else:
-            start, end = period_bounds(period)
-        
-        # Construiește filtrele doar dacă avem date valide
-        filters = []
-        if start:
-            filters.append(("gte", "timestamp", start))
-        if end:
-            filters.append(("lte", "timestamp", end))
-            
+        start, end, filters = self._prepare_period_filters(period, date_from, date_to)
+
         costs = self.db._table_select(COSTS_TABLE, "*", filters=filters) or []
         revs = self.db._table_select(REVENUE_TABLE, "*", filters=filters) or []
 
-        total_cost = sum(float(c.get("cost", 0)) for c in costs)
-        total_rev  = sum(float(r.get("amount", 0)) for r in revs)
+        total_cost = sum(float(c.get("cost", 0) or 0.0) for c in costs)
+        total_rev = sum(float(r.get("amount", 0) or 0.0) for r in revs)
         net_profit = total_rev - total_cost
         roi = ((total_rev - total_cost) / total_cost * 100.0) if total_cost > 0 else 0.0
+
+        cost_by_category: Dict[str, float] = defaultdict(float)
+        cost_by_provider: Dict[str, float] = defaultdict(float)
+        revenue_by_category: Dict[str, float] = defaultdict(float)
+        revenue_by_source: Dict[str, float] = defaultdict(float)
+
+        for cost in costs:
+            amount = float(cost.get("cost") or cost.get("amount") or 0.0)
+            provider = normalize_provider(cost.get("provider") or "Other")
+            category = self._get_cost_category(cost)
+            cost_by_category[category] += amount
+            cost_by_provider[provider or "Other"] += amount
+
+        for rev in revs:
+            amount = float(rev.get("amount") or 0.0)
+            source = rev.get("source") or rev.get("provider") or "Other"
+            category = self._get_revenue_category(rev)
+            revenue_by_source[source] += amount
+            revenue_by_category[category] += amount
+
+        daily_series = self._build_daily_series(costs, revs)
+        if daily_series:
+            cost_change = self._safe_div(
+                daily_series[-1]["costs"] - daily_series[0]["costs"],
+                abs(daily_series[0]["costs"]) or 1.0,
+            ) * 100.0
+            revenue_change = self._safe_div(
+                daily_series[-1]["revenue"] - daily_series[0]["revenue"],
+                abs(daily_series[0]["revenue"]) or 1.0,
+            ) * 100.0
+            profit_change = self._safe_div(
+                daily_series[-1]["profit"] - daily_series[0]["profit"],
+                abs(daily_series[0]["profit"]) or 1.0,
+            ) * 100.0
+        else:
+            cost_change = revenue_change = profit_change = 0.0
 
         return {
             "period": period if not date_from else "custom",
@@ -145,24 +307,443 @@ class FinancialService:
             "total_revenue": round(total_rev, 2),
             "net_profit": round(net_profit, 2),
             "roi_percentage": round(roi, 2),
-            "cost_breakdown": {"api_costs": round(total_cost, 2)},
-            "revenue_breakdown": {"all": round(total_rev, 2)},
-            "cost_change_percentage": 0.0,
-            "revenue_change_percentage": 0.0,
-            "profit_change_percentage": 0.0,
+            "cost_breakdown": {
+                "by_category": {k: round(v, 2) for k, v in cost_by_category.items()},
+                "by_provider": {k: round(v, 2) for k, v in cost_by_provider.items()},
+            },
+            "revenue_breakdown": {
+                "by_category": {k: round(v, 2) for k, v in revenue_by_category.items()},
+                "by_source": {k: round(v, 2) for k, v in revenue_by_source.items()},
+            },
+            "timeline": daily_series,
+            "cost_change_percentage": round(cost_change, 2),
+            "revenue_change_percentage": round(revenue_change, 2),
+            "profit_change_percentage": round(profit_change, 2),
             "roi_change_percentage": 0.0,
             "recommendations": self._recommendations(roi, total_cost, total_rev, net_profit)
         }
 
     def profit_loss_between(self, period: str = "30d") -> Dict[str, Any]:
-        data = self.roi_analysis(period)
-        pl = data["total_revenue"] - data["total_costs"]
-        data["profit_loss"] = round(pl, 2)
-        return data
+        return self.profit_loss_report(period=period)
 
     def dashboard(self, period: str = "7d", date_from: Optional[str] = None, date_to: Optional[str] = None) -> Dict[str, Any]:
-        # folosește roi_analysis cu date filtering
-        return self.roi_analysis(period=period, date_from=date_from, date_to=date_to)
+        analysis = self.roi_analysis(period=period, date_from=date_from, date_to=date_to)
+        alerts = self.get_budget_alerts()
+
+        timeline = analysis.get("timeline", []) or []
+        avg_profit = mean([row["profit"] for row in timeline]) if timeline else 0.0
+
+        top_costs = sorted(
+            (analysis.get("cost_breakdown", {}).get("by_provider", {}) or {}).items(),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+        top_revenue = sorted(
+            (analysis.get("revenue_breakdown", {}).get("by_source", {}) or {}).items(),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+
+        analysis.update(
+            {
+                "profit_margin": round(self._safe_div(analysis.get("net_profit", 0.0), analysis.get("total_revenue", 0.0)) * 100, 2),
+                "average_daily_profit": round(avg_profit, 2),
+                "top_cost_providers": [
+                    {"provider": provider, "amount": round(amount, 2)}
+                    for provider, amount in top_costs[:5]
+                ],
+                "top_revenue_sources": [
+                    {"source": source, "amount": round(amount, 2)}
+                    for source, amount in top_revenue[:5]
+                ],
+                "active_alerts": alerts[:5],
+                "cost_categories": analysis.get("cost_breakdown", {}).get("by_category", {}),
+                "revenue_categories": analysis.get("revenue_breakdown", {}).get("by_category", {}),
+            }
+        )
+
+        return analysis
+
+    # ----------------- AGREGĂRI AVANSATE -----------------
+
+    def financial_breakdown(
+        self,
+        period: str = "30d",
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        start, end, filters = self._prepare_period_filters(period, date_from, date_to)
+        costs = self.db._table_select(COSTS_TABLE, "*", filters=filters) or []
+        revs = self.db._table_select(REVENUE_TABLE, "*", filters=filters) or []
+
+        cost_by_category: Dict[str, float] = defaultdict(float)
+        cost_by_provider: Dict[str, float] = defaultdict(float)
+        revenue_by_category: Dict[str, float] = defaultdict(float)
+        revenue_by_source: Dict[str, float] = defaultdict(float)
+
+        for cost in costs:
+            amount = float(cost.get("cost") or cost.get("amount") or 0.0)
+            cost_by_category[self._get_cost_category(cost)] += amount
+            cost_by_provider[normalize_provider(cost.get("provider") or "Other") or "Other"] += amount
+
+        for rev in revs:
+            amount = float(rev.get("amount") or 0.0)
+            revenue_by_category[self._get_revenue_category(rev)] += amount
+            revenue_by_source[rev.get("source") or rev.get("provider") or "Other"] += amount
+
+        daily_series = self._build_daily_series(costs, revs)
+
+        cumulative_profit = 0.0
+        timeline = []
+        for entry in daily_series:
+            cumulative_profit += entry["profit"]
+            enriched = dict(entry)
+            enriched["cumulative_profit"] = round(cumulative_profit, 2)
+            timeline.append(enriched)
+
+        total_cost = sum(cost_by_category.values())
+        total_revenue = sum(revenue_by_category.values())
+        profit = total_revenue - total_cost
+
+        top_cost_items = sorted(costs, key=lambda c: float(c.get("cost") or 0.0), reverse=True)[:10]
+        top_revenue_items = sorted(revs, key=lambda r: float(r.get("amount") or 0.0), reverse=True)[:10]
+
+        return {
+            "period": period if not date_from else "custom",
+            "start_date": start[:10] if start else None,
+            "end_date": end[:10] if end else None,
+            "costs": {
+                "total": round(total_cost, 2),
+                "by_category": {k: round(v, 2) for k, v in cost_by_category.items()},
+                "by_provider": {k: round(v, 2) for k, v in cost_by_provider.items()},
+                "top": [
+                    {
+                        "id": item.get("id"),
+                        "provider": item.get("provider"),
+                        "operation": item.get("operation"),
+                        "category": self._get_cost_category(item),
+                        "amount": round(float(item.get("cost") or 0.0), 2),
+                        "timestamp": item.get("timestamp"),
+                    }
+                    for item in top_cost_items
+                ],
+            },
+            "revenue": {
+                "total": round(total_revenue, 2),
+                "by_category": {k: round(v, 2) for k, v in revenue_by_category.items()},
+                "by_source": {k: round(v, 2) for k, v in revenue_by_source.items()},
+                "top": [
+                    {
+                        "id": item.get("id"),
+                        "source": item.get("source"),
+                        "category": self._get_revenue_category(item),
+                        "amount": round(float(item.get("amount") or 0.0), 2),
+                        "timestamp": item.get("timestamp"),
+                    }
+                    for item in top_revenue_items
+                ],
+            },
+            "timeline": timeline,
+            "profitability": {
+                "net_profit": round(profit, 2),
+                "roi": round(self._safe_div(profit, total_cost) * 100, 2),
+                "profit_margin": round(self._safe_div(profit, total_revenue) * 100, 2),
+            },
+        }
+
+    def financial_forecast(
+        self,
+        period: str = "60d",
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        start, end, filters = self._prepare_period_filters(period, date_from, date_to)
+        costs = self.db._table_select(COSTS_TABLE, "*", filters=filters) or []
+        revs = self.db._table_select(REVENUE_TABLE, "*", filters=filters) or []
+
+        series = self._build_daily_series(costs, revs)
+        if not series:
+            return {
+                "period": period if not date_from else "custom",
+                "start_date": start[:10] if start else None,
+                "end_date": end[:10] if end else None,
+                "averages": {"revenue": 0.0, "costs": 0.0, "profit": 0.0},
+                "growth_rates": {"revenue": 0.0, "costs": 0.0, "profit": 0.0},
+                "forecasts": {},
+                "confidence": 0.35,
+                "series": series,
+            }
+
+        revenue_values = [row["revenue"] for row in series]
+        cost_values = [row["costs"] for row in series]
+        profit_values = [row["profit"] for row in series]
+
+        avg_revenue = mean(revenue_values)
+        avg_cost = mean(cost_values)
+        avg_profit = mean(profit_values)
+
+        def average_change(values: List[float]) -> float:
+            if len(values) < 2:
+                return 0.0
+            deltas = [values[i] - values[i - 1] for i in range(1, len(values))]
+            return mean(deltas)
+
+        revenue_change = average_change(revenue_values)
+        cost_change = average_change(cost_values)
+        profit_change = average_change(profit_values)
+
+        def project_future(last_value: float, avg_delta: float, days: int) -> float:
+            total = 0.0
+            current = last_value
+            for _ in range(days):
+                current = max(current + avg_delta, 0.0)
+                total += current
+            return round(total, 2)
+
+        horizons = {"7d": 7, "30d": 30, "90d": 90}
+        forecasts = {}
+        for label, days in horizons.items():
+            revenue_projection = project_future(revenue_values[-1], revenue_change, days)
+            cost_projection = project_future(cost_values[-1], cost_change, days)
+            profit_projection = revenue_projection - cost_projection
+            forecasts[label] = {
+                "revenue": round(revenue_projection, 2),
+                "costs": round(cost_projection, 2),
+                "profit": round(profit_projection, 2),
+                "trend": "up" if profit_projection >= 0 else "down",
+            }
+
+        revenue_volatility = pstdev(revenue_values) if len(revenue_values) > 1 else 0.0
+        volatility_factor = self._safe_div(revenue_volatility, avg_revenue or 1.0)
+        confidence = max(0.35, min(0.95, 1 / (1 + volatility_factor)))
+
+        growth_rates = {
+            "revenue": round(self._safe_div(revenue_change, avg_revenue or 1.0) * 100, 2),
+            "costs": round(self._safe_div(cost_change, avg_cost or 1.0) * 100, 2),
+            "profit": round(self._safe_div(profit_change, avg_profit or 1.0) * 100, 2),
+        }
+
+        return {
+            "period": period if not date_from else "custom",
+            "start_date": start[:10] if start else None,
+            "end_date": end[:10] if end else None,
+            "averages": {
+                "revenue": round(avg_revenue, 2),
+                "costs": round(avg_cost, 2),
+                "profit": round(avg_profit, 2),
+            },
+            "growth_rates": growth_rates,
+            "forecasts": forecasts,
+            "confidence": round(confidence, 2),
+            "series": series,
+        }
+
+    def profit_loss_report(
+        self,
+        period: str = "30d",
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        analysis = self.roi_analysis(period=period, date_from=date_from, date_to=date_to)
+        timeline = analysis.get("timeline", []) or []
+
+        profits = [row["profit"] for row in timeline]
+        avg_profit = mean(profits) if profits else 0.0
+        best_day = max(timeline, key=lambda row: row["profit"], default=None)
+        worst_day = min(timeline, key=lambda row: row["profit"], default=None)
+        volatility = pstdev(profits) if len(profits) > 1 else 0.0
+
+        cumulative = []
+        running_profit = 0.0
+        for row in timeline:
+            running_profit += row["profit"]
+            enriched = dict(row)
+            enriched["cumulative_profit"] = round(running_profit, 2)
+            cumulative.append(enriched)
+
+        analysis.update(
+            {
+                "daily_metrics": cumulative,
+                "avg_daily_profit": round(avg_profit, 2),
+                "best_day_profit": best_day["profit"] if best_day else 0.0,
+                "worst_day_profit": worst_day["profit"] if worst_day else 0.0,
+                "profit_volatility": round(volatility, 2),
+                "cost_categories": analysis.get("cost_breakdown", {}).get("by_category", {}),
+                "revenue_categories": analysis.get("revenue_breakdown", {}).get("by_category", {}),
+            }
+        )
+
+        return analysis
+
+    # ----------------- MANAGEMENT CATEGORII COST -----------------
+
+    def list_cost_categories(self) -> List[Dict[str, Any]]:
+        categories = self.db._table_select(COST_CATEGORY_TABLE, "*", order=("name", False)) or []
+        if categories:
+            return categories
+        return [dict(cat, is_default=True) for cat in DEFAULT_COST_CATEGORIES]
+
+    def create_cost_category(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        name = payload.get("name")
+        if not name:
+            raise ValueError("Category name is required")
+
+        slug = payload.get("slug") or name.lower().strip().replace(" ", "_")
+        category_data = {
+            "slug": slug,
+            "name": name,
+            "description": payload.get("description"),
+            "budget_cap": float(payload.get("budget_cap") or 0.0),
+            "color": payload.get("color") or "#64748b",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        return self.db._table_insert(COST_CATEGORY_TABLE, category_data)
+
+    def update_cost_category(self, slug: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {
+            key: value
+            for key, value in {
+                "name": payload.get("name"),
+                "description": payload.get("description"),
+                "budget_cap": float(payload.get("budget_cap")) if payload.get("budget_cap") is not None else None,
+                "color": payload.get("color"),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }.items()
+            if value is not None
+        }
+        if not payload:
+            raise ValueError("No fields provided for update")
+        return self.db._table_update_eq(COST_CATEGORY_TABLE, "slug", slug, payload)
+
+    def delete_cost_category(self, slug: str) -> Dict[str, Any]:
+        return self.db._table_delete_eq(COST_CATEGORY_TABLE, "slug", slug)
+
+    def assign_cost_category(self, cost_id: Any, category_slug: str) -> Dict[str, Any]:
+        cost_rows = self.db._table_select(COSTS_TABLE, "*", filters=[("eq", "id", cost_id)]) or []
+        if not cost_rows:
+            raise ValueError("Cost entry not found")
+
+        metadata = self._parse_metadata(cost_rows[0].get("metadata"))
+        metadata["category"] = category_slug
+
+        payload = {
+            "metadata": metadata,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        return self.db._table_update_eq(COSTS_TABLE, "id", cost_id, payload)
+
+    # ----------------- EXPORTURI -----------------
+
+    def export_financial_data(
+        self,
+        period: str = "30d",
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+        include_costs: bool = True,
+        include_revenue: bool = True,
+    ) -> Dict[str, Any]:
+        start, end, filters = self._prepare_period_filters(period, date_from, date_to)
+        costs = self.db._table_select(COSTS_TABLE, "*", filters=filters) if include_costs else []
+        revenues = self.db._table_select(REVENUE_TABLE, "*", filters=filters) if include_revenue else []
+        metrics = self.roi_analysis(period=period, date_from=date_from, date_to=date_to)
+
+        return {
+            "period": period if not date_from else "custom",
+            "start_date": start[:10] if start else None,
+            "end_date": end[:10] if end else None,
+            "costs": costs or [],
+            "revenues": revenues or [],
+            "metrics": metrics,
+        }
+
+    def generate_invoice_pdf(self, invoice_id: str) -> Tuple[bytes, Dict[str, Any]]:
+        invoice_rows = self.db._table_select(INVOICE_TABLE, "*", filters=[("eq", "id", invoice_id)]) or []
+        if not invoice_rows:
+            raise ValueError("Invoice not found")
+        invoice = invoice_rows[0]
+        pdf_bytes = self._render_invoice_pdf(invoice)
+        return pdf_bytes, invoice
+
+    def _render_invoice_pdf(self, invoice: Dict[str, Any]) -> bytes:
+        """Generează un PDF simplificat pentru factură fără dependențe externe."""
+
+        def sanitize(text: Any) -> str:
+            value = str(text or "")
+            return (
+                value
+                .replace("\\", "\\\\")
+                .replace("(", "\\(")
+                .replace(")", "\\)")
+                .encode("latin-1", "ignore")
+                .decode("latin-1")
+            )
+
+        lines = [
+            f"Factura #{invoice.get('number') or invoice.get('id')}",
+            f"Client: {invoice.get('client_name', 'N/A')}",
+            f"Email: {invoice.get('client_email', 'N/A')}",
+            f"Adresă: {invoice.get('client_address', 'N/A')}",
+            "",
+            f"Data emiterii: {invoice.get('created_at', '')}",
+            f"Scadență: {invoice.get('due_date', '')}",
+            "",
+            "Detalii articole:",
+        ]
+
+        for item in invoice.get("items", []) or []:
+            label = item.get("description") or item.get("name") or "Serviciu"
+            qty = item.get("quantity", 1)
+            total = float(item.get("total") or 0.0)
+            lines.append(f" - {label} x{qty}: {total:.2f} EUR")
+
+        lines.extend(
+            [
+                "",
+                f"Subtotal: {float(invoice.get('subtotal') or 0.0):.2f} EUR",
+                f"Taxe: {float(invoice.get('tax_amount') or 0.0):.2f} EUR",
+                f"Total: {float(invoice.get('total') or 0.0):.2f} EUR",
+            ]
+        )
+
+        content_lines = ["BT", "/F1 12 Tf", "72 800 Td"]
+        for line in lines:
+            content_lines.append(f"({sanitize(line)}) Tj")
+            content_lines.append("0 -18 Td")
+        content_lines.append("ET")
+        content = "\n".join(content_lines)
+        content_bytes = content.encode("latin-1")
+
+        objects: List[str] = []
+
+        def add_object(obj: str) -> None:
+            objects.append(obj + "\n")
+
+        add_object("1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj")
+        add_object("2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj")
+        add_object("3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj")
+        add_object(f"4 0 obj << /Length {len(content_bytes)} >> stream\n{content}\nendstream endobj")
+        add_object("5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj")
+
+        pdf_body = "%PDF-1.4\n"
+        offsets = [len(pdf_body.encode("latin-1"))]
+        for obj in objects:
+            pdf_body += obj
+            offsets.append(len(pdf_body.encode("latin-1")))
+
+        xref_start = len(pdf_body.encode("latin-1"))
+        pdf_body += "xref\n0 6\n0000000000 65535 f \n"
+        current_offset = 0
+        for idx, obj in enumerate(objects, start=1):
+            # compute offset for object idx
+            if idx == 1:
+                current_offset = offsets[0]
+            else:
+                current_offset = offsets[idx - 1]
+            pdf_body += f"{current_offset:010} 00000 n \n"
+        pdf_body += "trailer << /Size 6 /Root 1 0 R >>\n"
+        pdf_body += f"startxref\n{xref_start}\n%%EOF"
+
+        return pdf_body.encode("latin-1")
 
     def _recommendations(self, roi_pct: float, total_costs: float, total_revenue: float, net_profit: float) -> List[str]:
         rec = []

--- a/services/api/app/tests/test_financial_service.py
+++ b/services/api/app/tests/test_financial_service.py
@@ -1,0 +1,146 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from services.api.app.services.financial.service import FinancialService
+
+
+class StubSupabaseService:
+    def __init__(self):
+        self.tables = {
+            'api_costs': [
+                {
+                    'id': 1,
+                    'provider': 'OpenAI',
+                    'operation': 'chat',
+                    'cost': 120.0,
+                    'timestamp': '2025-01-01T10:00:00Z',
+                    'metadata': {'category': 'AI'}
+                },
+                {
+                    'id': 2,
+                    'provider': 'Meta',
+                    'operation': 'ads',
+                    'cost': 80.0,
+                    'timestamp': '2025-01-02T10:00:00Z',
+                    'metadata': {'category': 'Marketing'}
+                },
+            ],
+            'revenues': [
+                {
+                    'id': 1,
+                    'source': 'ClientA',
+                    'amount': 500.0,
+                    'timestamp': '2025-01-01T15:00:00Z',
+                    'metadata': {'category': 'Legal Services'}
+                },
+                {
+                    'id': 2,
+                    'source': 'ClientB',
+                    'amount': 450.0,
+                    'timestamp': '2025-01-02T16:00:00Z',
+                    'metadata': {'category': 'Legal Services'}
+                },
+            ],
+            'cost_categories': [],
+            'invoices': [
+                {
+                    'id': 'inv-1',
+                    'number': 'INV-1',
+                    'client_name': 'Test Client',
+                    'client_email': 'client@example.com',
+                    'client_address': 'Str. Exemplu 1',
+                    'due_date': '2025-02-01',
+                    'tax_rate': 0.19,
+                    'subtotal': 1000.0,
+                    'tax_amount': 190.0,
+                    'total': 1190.0,
+                    'items': [{'description': 'Serviciu', 'quantity': 1, 'total': 1000.0}],
+                    'notes': None,
+                    'created_at': '2025-01-01T12:00:00Z'
+                }
+            ]
+        }
+
+    def _table_select(self, table: str, *_cols, filters=None, order=None, limit=None):
+        data = list(self.tables.get(table, []))
+        if filters:
+            for op, field, value in filters:
+                if op == 'eq':
+                    data = [row for row in data if row.get(field) == value]
+        if order:
+            key, desc = order
+            data.sort(key=lambda row: row.get(key), reverse=desc)
+        if limit:
+            data = data[:limit]
+        return data
+
+    def _table_insert(self, table: str, payload: dict):
+        self.tables.setdefault(table, []).append(payload)
+        return payload
+
+    def _table_update_eq(self, table: str, field: str, value, payload: dict):
+        updated = []
+        for row in self.tables.get(table, []):
+            if row.get(field) == value:
+                row.update(payload)
+                updated.append(row)
+        return updated
+
+    def _table_delete_eq(self, table: str, field: str, value):
+        rows = self.tables.get(table, [])
+        before = len(rows)
+        self.tables[table] = [row for row in rows if row.get(field) != value]
+        return {"success": True, "deleted": before - len(self.tables[table])}
+
+
+@pytest.fixture
+def financial_service():
+    return FinancialService(StubSupabaseService())
+
+
+def test_financial_breakdown(financial_service):
+    breakdown = financial_service.financial_breakdown(period='7d')
+    assert breakdown['costs']['total'] == 200.0
+    assert breakdown['revenue']['total'] == 950.0
+    assert breakdown['profitability']['net_profit'] == 750.0
+    assert len(breakdown['timeline']) == 2
+
+
+def test_financial_forecast(financial_service):
+    forecast = financial_service.financial_forecast(period='7d')
+    assert 'averages' in forecast
+    assert 'forecasts' in forecast
+    assert forecast['forecasts']['7d']['revenue'] >= 0
+
+
+def test_profit_loss_report(financial_service):
+    report = financial_service.profit_loss_report(period='7d')
+    assert report['total_revenue'] == 950.0
+    assert report['total_costs'] == 200.0
+    assert report['avg_daily_profit'] >= 0
+    assert isinstance(report['daily_metrics'], list)
+
+
+def test_cost_category_management(financial_service):
+    defaults = financial_service.list_cost_categories()
+    assert defaults, "Default categories should be returned when table empty"
+    created = financial_service.create_cost_category({
+        'name': 'Test Category',
+        'budget_cap': 1000,
+        'color': '#ffffff'
+    })
+    assert created['name'] == 'Test Category'
+    financial_service.assign_cost_category(1, created['slug'])
+    financial_service.delete_cost_category(created['slug'])
+
+
+def test_generate_invoice_pdf(financial_service):
+    pdf_bytes, invoice = financial_service.generate_invoice_pdf('inv-1')
+    assert invoice['id'] == 'inv-1'
+    assert pdf_bytes.startswith(b'%PDF')


### PR DESCRIPTION
## Summary
- implement detailed financial aggregations including breakdown, forecasting, profit/loss analysis, cost categories, and invoice export in the financial service
- expose new analytics endpoints and schemas while updating OpenAPI documentation for the extended contract
- enhance the financial dashboard UI with Recharts visualizations, MRR/tax sections, and updated client types and API helpers
- add unit coverage for the financial service

## Testing
- pytest services/api/app/tests/test_financial_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e95b65ce3c8323bd6068695296d6a8