### PR TITLE
Add configuration and redis helpers for tests

### DIFF
--- a/services/api/app/__init__.py
+++ b/services/api/app/__init__.py
@@ -1,0 +1,4 @@
+"""AutoPro Daune API application package."""
+from .core import Settings, get_redis, get_settings
+
+__all__ = ["Settings", "get_settings", "get_redis"]

--- a/services/api/app/core/__init__.py
+++ b/services/api/app/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities exposed for dependency injection."""
+from .config import Settings, get_settings
+from .redis_client import get_redis
+
+__all__ = ["Settings", "get_settings", "get_redis"]

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -1,0 +1,52 @@
+"""Application configuration utilities."""
+from functools import lru_cache
+from typing import List, Optional
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=True,
+    )
+
+    ENVIRONMENT: str = "development"
+    DEBUG: bool = False
+
+    SECRET_KEY: str = "change-me"
+    JWT_SECRET_KEY: Optional[str] = None
+
+    SUPABASE_URL: Optional[str] = None
+    SUPABASE_KEY: Optional[str] = None
+    SUPABASE_SERVICE_KEY: Optional[str] = None
+
+    REDIS_URL: str = "redis://localhost:6379/0"
+    REDIS_PASSWORD: Optional[str] = None
+
+    BACKEND_CORS_ORIGINS: List[str] = Field(default_factory=list)
+    LOG_LEVEL: str = "INFO"
+
+    @field_validator("BACKEND_CORS_ORIGINS", mode="before")
+    @classmethod
+    def split_cors_origins(cls, value: Optional[str | List[str]]) -> List[str]:
+        """Allow comma-separated values for CORS origins."""
+
+        if value is None:
+            return []
+        if isinstance(value, str):
+            if not value:
+                return []
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return list(value)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached ``Settings`` instance."""
+
+    return Settings()

--- a/services/api/app/core/redis_client.py
+++ b/services/api/app/core/redis_client.py
@@ -1,0 +1,24 @@
+"""Redis client helper for dependency injection."""
+from __future__ import annotations
+
+from typing import Optional
+
+from redis.asyncio import Redis
+
+from .config import get_settings
+
+_redis_client: Optional[Redis] = None
+
+
+def get_redis() -> Redis:
+    """Return a cached Redis client configured from settings."""
+
+    global _redis_client
+    if _redis_client is None:
+        settings = get_settings()
+        _redis_client = Redis.from_url(
+            settings.REDIS_URL,
+            password=settings.REDIS_PASSWORD,
+            decode_responses=True,
+        )
+    return _redis_client


### PR DESCRIPTION
## Summary
- add a pydantic-based Settings helper with a cached accessor
- provide a reusable Redis dependency helper and expose it via package exports

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68e9671f50e08323859ce11b57e63001