### PR TITLE
Integrate business metrics collector with Supabase services

### DIFF
--- a/services/api/app/services/monitoring/collectors.py
+++ b/services/api/app/services/monitoring/collectors.py
@@ -5,9 +5,19 @@ Monitoring Collectors - Individual metric collectors for system and business met
 import time
 import psutil
 import logging
-from typing import List
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from datetime import datetime
+
+from ..analytics.models import (
+    MetricData as AnalyticsMetricData,
+    MetricType as AnalyticsMetricType,
+    DataSource as AnalyticsDataSource,
+)
 from .models import Metric, MetricType
+
+if TYPE_CHECKING:
+    from ..supabase_client import SupabaseService
+    from ..analytics.processor import AnalyticsProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -175,110 +185,346 @@ class SystemMetricsCollector:
 
 class BusinessMetricsCollector:
     """Colector pentru metrici de business"""
-    
-    def __init__(self):
-        pass
+
+    def __init__(
+        self,
+        supabase_service: Optional["SupabaseService"] = None,
+        analytics_processor: Optional["AnalyticsProcessor"] = None,
+    ):
+        self.supabase_service = supabase_service
+        self.analytics_processor = analytics_processor
+
+    @staticmethod
+    def _to_float(value: Any) -> Optional[float]:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_timestamp(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                # Support timestamps that end with "Z" or include timezone info
+                normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+                return datetime.fromisoformat(normalized)
+            except ValueError:
+                pass
+        return datetime.now()
+
+    def _append_metric(
+        self,
+        metrics: List[Metric],
+        *,
+        name: str,
+        value: Any,
+        metric_type: MetricType,
+        labels: Dict[str, str],
+        timestamp: datetime,
+        description: str,
+    ) -> None:
+        numeric_value = self._to_float(value)
+        if numeric_value is None:
+            return
+        metrics.append(
+            Metric(
+                name=name,
+                value=numeric_value,
+                metric_type=metric_type,
+                labels=labels,
+                timestamp=timestamp,
+                description=description,
+            )
+        )
+
+    def _build_analytics_metric(
+        self,
+        *,
+        name: str,
+        value: float,
+        timestamp: datetime,
+        labels: Dict[str, str],
+        source: AnalyticsDataSource,
+    ) -> AnalyticsMetricData:
+        return AnalyticsMetricData(
+            name=name,
+            value=value,
+            metric_type=AnalyticsMetricType.GAUGE,
+            labels=labels,
+            timestamp=timestamp,
+            source=source,
+            description=f"Collected via {source.value} source",
+        )
     
     def collect_financial_metrics(self) -> List[Metric]:
         """Colectează metrici financiare"""
-        metrics = []
-        
+        metrics: List[Metric] = []
+
+        if not self.supabase_service:
+            logger.warning("Supabase service not configured for financial metrics collection")
+            return metrics
+
         try:
-            # Simulează colectarea metricilor financiare
-            # În implementarea reală, ar citi din baza de date
-            
-            metrics.extend([
-                Metric(
-                    name="business_revenue_daily",
-                    value=1250.0,
-                    metric_type=MetricType.GAUGE,
-                    labels={"currency": "RON", "period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Daily revenue"
-                ),
-                Metric(
-                    name="business_costs_daily",
-                    value=450.0,
-                    metric_type=MetricType.GAUGE,
-                    labels={"currency": "RON", "period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Daily costs"
-                ),
-                Metric(
-                    name="business_roi_percentage",
-                    value=177.8,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Return on Investment percentage"
-                ),
-                Metric(
-                    name="business_leads_total",
-                    value=150,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Total leads received"
-                ),
-                Metric(
-                    name="business_conversions_total",
-                    value=45,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Total conversions"
+            dashboard = self.supabase_service.financial_dashboard()
+        except Exception as exc:
+            logger.error("Error collecting financial metrics from Supabase: %s", exc, exc_info=True)
+            return metrics
+
+        timestamp = datetime.now()
+
+        self._append_metric(
+            metrics,
+            name="business_total_revenue",
+            value=(dashboard or {}).get("total_revenue"),
+            metric_type=MetricType.GAUGE,
+            labels={"currency": "EUR", "aggregation": "total"},
+            timestamp=timestamp,
+            description="Total revenue reported by Supabase dashboard",
+        )
+        self._append_metric(
+            metrics,
+            name="business_total_costs",
+            value=(dashboard or {}).get("total_costs"),
+            metric_type=MetricType.GAUGE,
+            labels={"currency": "EUR", "aggregation": "total"},
+            timestamp=timestamp,
+            description="Total costs reported by Supabase dashboard",
+        )
+        self._append_metric(
+            metrics,
+            name="business_net_profit",
+            value=(dashboard or {}).get("net_profit"),
+            metric_type=MetricType.GAUGE,
+            labels={"currency": "EUR", "aggregation": "total"},
+            timestamp=timestamp,
+            description="Net profit calculated from Supabase dashboard",
+        )
+        self._append_metric(
+            metrics,
+            name="business_roi_percentage",
+            value=(dashboard or {}).get("roi_percentage"),
+            metric_type=MetricType.GAUGE,
+            labels={"aggregation": "total"},
+            timestamp=timestamp,
+            description="ROI percentage calculated from Supabase dashboard",
+        )
+
+        recent_revenues = (dashboard or {}).get("recent_revenues") or []
+        recent_costs = (dashboard or {}).get("recent_costs") or []
+
+        for index, revenue in enumerate(recent_revenues):
+            amount = self._to_float((revenue or {}).get("amount"))
+            if amount is None:
+                continue
+            revenue_timestamp = self._parse_timestamp((revenue or {}).get("timestamp"))
+            labels = {
+                "entry": str(index),
+                "category": "revenue",
+                "currency": (revenue or {}).get("currency", "EUR"),
+            }
+            self._append_metric(
+                metrics,
+                name="business_recent_revenue_amount",
+                value=amount,
+                metric_type=MetricType.GAUGE,
+                labels=labels,
+                timestamp=revenue_timestamp,
+                description="Recent revenue entry fetched from Supabase",
+            )
+
+        for index, cost in enumerate(recent_costs):
+            amount = self._to_float((cost or {}).get("cost"))
+            if amount is None:
+                continue
+            cost_timestamp = self._parse_timestamp((cost or {}).get("timestamp"))
+            labels = {
+                "entry": str(index),
+                "category": "cost",
+                "currency": (cost or {}).get("currency", "EUR"),
+            }
+            self._append_metric(
+                metrics,
+                name="business_recent_cost_amount",
+                value=amount,
+                metric_type=MetricType.GAUGE,
+                labels=labels,
+                timestamp=cost_timestamp,
+                description="Recent cost entry fetched from Supabase",
+            )
+
+        analytics_metrics: List[AnalyticsMetricData] = []
+        for revenue in recent_revenues:
+            amount = self._to_float((revenue or {}).get("amount"))
+            if amount is None:
+                continue
+            analytics_metrics.append(
+                self._build_analytics_metric(
+                    name="recent_revenue",
+                    value=amount,
+                    timestamp=self._parse_timestamp((revenue or {}).get("timestamp")),
+                    labels={"category": "revenue"},
+                    source=AnalyticsDataSource.FINANCIAL,
                 )
-            ])
-            
-        except Exception as e:
-            logger.error(f"Error collecting financial metrics: {str(e)}")
-        
+            )
+
+        for cost in recent_costs:
+            amount = self._to_float((cost or {}).get("cost"))
+            if amount is None:
+                continue
+            analytics_metrics.append(
+                self._build_analytics_metric(
+                    name="recent_cost",
+                    value=amount,
+                    timestamp=self._parse_timestamp((cost or {}).get("timestamp")),
+                    labels={"category": "cost"},
+                    source=AnalyticsDataSource.FINANCIAL,
+                )
+            )
+
+        if self.analytics_processor and analytics_metrics:
+            try:
+                analytics_summary = self.analytics_processor.process_metrics(analytics_metrics)
+            except Exception as exc:
+                logger.error("Error processing financial analytics metrics: %s", exc, exc_info=True)
+            else:
+                total_metrics = analytics_summary.get("total_metrics")
+                if isinstance(total_metrics, (int, float)):
+                    self._append_metric(
+                        metrics,
+                        name="business_financial_recent_activity_count",
+                        value=total_metrics,
+                        metric_type=MetricType.GAUGE,
+                        labels={"aggregation": "count", "source": "supabase"},
+                        timestamp=timestamp,
+                        description="Number of recent financial entries processed",
+                    )
+
+                financial_totals = (analytics_summary.get("sources") or {}).get(AnalyticsDataSource.FINANCIAL.value, {})
+                total_value = financial_totals.get("total_value")
+                if isinstance(total_value, (int, float)):
+                    self._append_metric(
+                        metrics,
+                        name="business_financial_recent_activity_total_value",
+                        value=total_value,
+                        metric_type=MetricType.GAUGE,
+                        labels={"aggregation": "sum", "source": "supabase"},
+                        timestamp=timestamp,
+                        description="Aggregated total value for recent financial entries",
+                    )
+
         return metrics
     
     def collect_social_media_metrics(self) -> List[Metric]:
         """Colectează metrici de social media"""
-        metrics = []
-        
+        metrics: List[Metric] = []
+
+        if not self.supabase_service:
+            logger.warning("Supabase service not configured for social media metrics collection")
+            return metrics
+
         try:
-            # Simulează colectarea metricilor de social media
-            metrics.extend([
-                Metric(
-                    name="social_media_posts_total",
-                    value=25,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Total social media posts"
-                ),
-                Metric(
-                    name="social_media_views_total",
-                    value=45678,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Total social media views"
-                ),
-                Metric(
-                    name="social_media_engagement_total",
-                    value=1234,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Total social media engagement"
-                ),
-                Metric(
-                    name="social_media_followers_total",
-                    value=2500,
-                    metric_type=MetricType.GAUGE,
-                    labels={"period": "daily"},
-                    timestamp=datetime.now(),
-                    description="Total social media followers"
-                )
-            ])
-            
-        except Exception as e:
-            logger.error(f"Error collecting social media metrics: {str(e)}")
-        
+            summary = self.supabase_service.social_summary()
+        except Exception as exc:
+            logger.error("Error collecting social media metrics from Supabase: %s", exc, exc_info=True)
+            return metrics
+
+        timestamp = datetime.now()
+        analytics_metrics: List[AnalyticsMetricData] = []
+
+        for platform, stats in (summary or {}).items():
+            if not isinstance(stats, dict):
+                continue
+
+            self._append_metric(
+                metrics,
+                name="social_media_posts_today",
+                value=stats.get("posts_today"),
+                metric_type=MetricType.GAUGE,
+                labels={"platform": platform, "period": "daily"},
+                timestamp=timestamp,
+                description="Number of posts published today",
+            )
+            self._append_metric(
+                metrics,
+                name="social_media_followers_total",
+                value=stats.get("followers") or stats.get("followers_total"),
+                metric_type=MetricType.GAUGE,
+                labels={"platform": platform},
+                timestamp=timestamp,
+                description="Total followers per platform",
+            )
+            self._append_metric(
+                metrics,
+                name="social_media_engagement_rate",
+                value=stats.get("engagement_rate") or stats.get("engagement"),
+                metric_type=MetricType.GAUGE,
+                labels={"platform": platform},
+                timestamp=timestamp,
+                description="Engagement rate for the platform",
+            )
+            self._append_metric(
+                metrics,
+                name="social_media_revenue_total",
+                value=stats.get("revenue"),
+                metric_type=MetricType.GAUGE,
+                labels={"platform": platform, "currency": stats.get("currency", "EUR")},
+                timestamp=timestamp,
+                description="Total revenue attributed to the platform",
+            )
+
+            if self.analytics_processor:
+                for metric_name, key in (
+                    ("posts_today", "posts_today"),
+                    ("followers", "followers"),
+                    ("engagement_rate", "engagement_rate"),
+                    ("revenue", "revenue"),
+                ):
+                    numeric_value = self._to_float(stats.get(key))
+                    if numeric_value is None:
+                        continue
+                    analytics_metrics.append(
+                        self._build_analytics_metric(
+                            name=f"{platform}_{metric_name}",
+                            value=numeric_value,
+                            timestamp=timestamp,
+                            labels={"platform": platform, "metric": metric_name},
+                            source=AnalyticsDataSource.SOCIAL_MEDIA,
+                        )
+                    )
+
+        if self.analytics_processor and analytics_metrics:
+            try:
+                social_summary = self.analytics_processor.process_metrics(analytics_metrics)
+            except Exception as exc:
+                logger.error("Error processing social media analytics metrics: %s", exc, exc_info=True)
+            else:
+                total_metrics = social_summary.get("total_metrics")
+                if isinstance(total_metrics, (int, float)):
+                    self._append_metric(
+                        metrics,
+                        name="social_media_metrics_count",
+                        value=total_metrics,
+                        metric_type=MetricType.GAUGE,
+                        labels={"aggregation": "count", "source": "supabase"},
+                        timestamp=timestamp,
+                        description="Number of social media metrics processed",
+                    )
+
+                social_totals = (social_summary.get("sources") or {}).get(AnalyticsDataSource.SOCIAL_MEDIA.value, {})
+                total_value = social_totals.get("total_value")
+                if isinstance(total_value, (int, float)):
+                    self._append_metric(
+                        metrics,
+                        name="social_media_metrics_total_value",
+                        value=total_value,
+                        metric_type=MetricType.GAUGE,
+                        labels={"aggregation": "sum", "source": "supabase"},
+                        timestamp=timestamp,
+                        description="Aggregated total value for social media metrics",
+                    )
+
         return metrics
     
     def collect_video_generation_metrics(self) -> List[Metric]:

--- a/services/api/app/services/monitoring/service.py
+++ b/services/api/app/services/monitoring/service.py
@@ -16,10 +16,35 @@ logger = logging.getLogger(__name__)
 
 class MonitoringService:
     """Serviciu principal de monitoring"""
-    
-    def __init__(self):
+
+    def __init__(self, supabase_service=None, analytics_processor=None):
         self.system_collector = SystemMetricsCollector()
-        self.business_collector = BusinessMetricsCollector()
+
+        self.supabase_service = supabase_service
+        self.analytics_processor = analytics_processor
+
+        if self.supabase_service is None:
+            try:
+                from ..supabase_client import get_supabase_service_instance
+
+                self.supabase_service = get_supabase_service_instance()
+            except Exception as exc:
+                logger.warning("Supabase service unavailable for monitoring: %s", exc)
+                self.supabase_service = None
+
+        if self.analytics_processor is None:
+            try:
+                from ..analytics.processor import AnalyticsProcessor
+
+                self.analytics_processor = AnalyticsProcessor()
+            except Exception as exc:
+                logger.warning("AnalyticsProcessor unavailable for monitoring: %s", exc)
+                self.analytics_processor = None
+
+        self.business_collector = BusinessMetricsCollector(
+            supabase_service=self.supabase_service,
+            analytics_processor=self.analytics_processor,
+        )
         self.alert_manager = AlertManager()
         self.metrics_history = []
         

--- a/services/api/app/services/monitoring/tests/test_business_metrics_collector.py
+++ b/services/api/app/services/monitoring/tests/test_business_metrics_collector.py
@@ -1,0 +1,88 @@
+import pytest
+
+from ..collectors import BusinessMetricsCollector
+from ...analytics.processor import AnalyticsProcessor
+
+
+class FakeSupabaseService:
+    def __init__(self):
+        self.financial_calls = 0
+        self.social_calls = 0
+
+    def financial_dashboard(self):
+        self.financial_calls += 1
+        return {
+            "total_revenue": 1250.0,
+            "total_costs": 450.0,
+            "net_profit": 800.0,
+            "roi_percentage": 177.78,
+            "recent_revenues": [
+                {"amount": 750.0, "timestamp": "2024-01-02T10:00:00Z", "currency": "EUR"},
+                {"amount": 500.0, "timestamp": "2024-01-01T10:00:00Z", "currency": "EUR"},
+            ],
+            "recent_costs": [
+                {"cost": 250.0, "timestamp": "2024-01-02T09:30:00Z", "currency": "EUR"},
+            ],
+        }
+
+    def social_summary(self):
+        self.social_calls += 1
+        return {
+            "tiktok": {
+                "posts_today": 3,
+                "followers": 1520,
+                "engagement_rate": 4.5,
+                "revenue": 95.0,
+            },
+            "instagram": {
+                "posts_today": 2,
+                "followers": 980,
+                "engagement_rate": 3.1,
+                "revenue": 45.5,
+            },
+        }
+
+
+@pytest.fixture
+def collector():
+    supabase = FakeSupabaseService()
+    analytics_processor = AnalyticsProcessor()
+    return supabase, BusinessMetricsCollector(supabase, analytics_processor)
+
+
+def test_collect_financial_metrics_queries_supabase(collector):
+    supabase, business_collector = collector
+
+    metrics = business_collector.collect_financial_metrics()
+
+    assert supabase.financial_calls == 1, "financial_dashboard should be queried"
+
+    metric_map = {metric.name: metric for metric in metrics}
+
+    assert metric_map["business_total_revenue"].value == pytest.approx(1250.0)
+    assert metric_map["business_total_costs"].value == pytest.approx(450.0)
+    assert metric_map["business_net_profit"].value == pytest.approx(800.0)
+
+    recent_metrics = [m for m in metrics if m.name == "business_financial_recent_activity_count"]
+    assert recent_metrics, "expected analytics aggregation metric for financial data"
+    assert recent_metrics[0].value >= 1
+
+
+def test_collect_social_media_metrics_queries_supabase(collector):
+    supabase, business_collector = collector
+
+    metrics = business_collector.collect_social_media_metrics()
+
+    assert supabase.social_calls == 1, "social_summary should be queried"
+
+    followers_metrics = [
+        m
+        for m in metrics
+        if m.name == "social_media_followers_total" and m.labels.get("platform") == "tiktok"
+    ]
+    assert followers_metrics, "expected follower metric for TikTok platform"
+    assert followers_metrics[0].value == pytest.approx(1520)
+
+    count_metrics = [m for m in metrics if m.name == "social_media_metrics_count"]
+    assert count_metrics, "expected analytics aggregation metric for social data"
+    assert count_metrics[0].value >= 1


### PR DESCRIPTION
## Summary
- inject Supabase and analytics dependencies into the business metrics collector and build metrics from live dashboard and social summaries
- fall back gracefully when upstream services are unavailable and surface aggregated analytics metrics for recent financial and social data
- extend the monitoring service wiring and add unit coverage that validates the collector queries mocked Supabase data

## Testing
- pytest services/api/app/services/monitoring/tests/test_business_metrics_collector.py


------
https://chatgpt.com/codex/tasks/task_e_68ea0e76cd808323a624dc54e7dc6495