### PR TITLE
Gracefully skip analytics metrics when dependencies missing

### DIFF
--- a/services/api/app/services/analytics/collectors.py
+++ b/services/api/app/services/analytics/collectors.py
@@ -309,10 +309,18 @@ class VideoGenerationCollector(BaseMetricsCollector):
     async def _get_video_metrics_from_dependencies(self) -> Optional[Any]:
         """Extrage metricile de generare video din dependențele configurate."""
 
-        if not any([self.supabase_client, self.cache, self.video_metrics_repository, self.external_api]):
-            raise RuntimeError(
-                "Niciun provider de date configurat pentru metricile de generare video"
+        if not any(
+            [
+                self.supabase_client,
+                self.cache,
+                self.video_metrics_repository,
+                self.external_api,
+            ]
+        ):
+            logger.info(
+                "Colectorul VideoGeneration nu are provideri configurați; se întorc metrici implicite goale"
             )
+            return []
 
         data = await self._fetch_from_cache("video_generation_metrics")
         if data:
@@ -390,10 +398,18 @@ class FinancialCollector(BaseMetricsCollector):
         return metrics
 
     async def _get_financial_metrics_from_dependencies(self) -> Optional[Any]:
-        if not any([self.supabase_client, self.cache, self.financial_repository, self.accounting_api]):
-            raise RuntimeError(
-                "Niciun provider de date configurat pentru metricile financiare"
+        if not any(
+            [
+                self.supabase_client,
+                self.cache,
+                self.financial_repository,
+                self.accounting_api,
+            ]
+        ):
+            logger.info(
+                "Colectorul Financial nu are provideri configurați; se întorc metrici implicite goale"
             )
+            return []
 
         data = await self._fetch_from_cache("financial_metrics")
         if data:


### PR DESCRIPTION
## Summary
- avoid raising runtime errors in video and financial collectors when no providers are configured
- log that default empty metrics are returned so the analytics reporter keeps working without injected dependencies

## Testing
- python -m compileall services/api/app/services/analytics/collectors.py services/api/app/services/analytics/processor.py

------
https://chatgpt.com/codex/tasks/task_e_68ea12752b8883238b6e6068155510b3